### PR TITLE
change file encoding, fix utf8 test cases

### DIFF
--- a/src/avro_binary_decoder.erl
+++ b/src/avro_binary_decoder.erl
@@ -46,8 +46,8 @@ decode(IoData, Type, LookupFun) ->
   {Value, <<>>} = do_decode(IoData, Type, LookupFun),
   Value.
 
-%% @doc Decode the header of a byte stream, return unwrapped value and tail bytes
-%% in a tuple.
+%% @doc Decode the header of a byte stream,
+%% return unwrapped value and tail bytes in a tuple.
 %% @end
 -spec decode_stream(iodata(), string() | avro_type(),
                     fun((string()) -> avro_type())) -> term().
@@ -126,7 +126,7 @@ prim(Bin, "bytes") ->
   bytes(Bin);
 prim(Bin, "string") ->
   {Bytes, Tail} = bytes(Bin),
-  {unicode:characters_to_list(Bytes, utf8), Tail}.
+  {binary_to_list(Bytes), Tail}.
 
 bytes(Bin) ->
   {Size, Rest} = long(Bin),
@@ -237,10 +237,11 @@ decode_string_test() ->
   ?assertEqual(Str, decode_t(Enc, avro_primitive:string_type())).
 
 decode_utf8_string_test() ->
-  Str = "Avro Ã¤r populÃ¤r",
-  Utf8 = xmerl_ucs:to_utf8(Str),
-  Enc = [42, Utf8],
-  ?assertEqual(Str, decode_t(Enc, avro_primitive:string_type())).
+  Str = "Avro är populär",
+  Utf8 = unicode:characters_to_binary(Str, latin1, utf8),
+  Enc = [size(Utf8) * 2, Utf8],
+  ?assertEqual(binary_to_list(Utf8), decode_t(Enc, avro_primitive:string_type())),
+  ?assertEqual(Str, unicode:characters_to_list(Utf8, utf8)).
 
 decode_empty_array_test() ->
   Type = avro_array:type(avro_primitive:int_type()),

--- a/src/avro_binary_encoder.erl
+++ b/src/avro_binary_encoder.erl
@@ -225,7 +225,8 @@ varint(I) ->
 
 -ifdef(EUNIT).
 
--define(assertBinEq(A,B), ?assertEqual(iolist_to_binary(A),iolist_to_binary(B))).
+-define(assertBinEq(A,B),
+        ?assertEqual(iolist_to_binary(A),iolist_to_binary(B))).
 
 encode_null_test() ->
   BinNull = encode_value(avro_primitive:null()),
@@ -298,10 +299,9 @@ encode_string_with_quoting_test() ->
   ?assertBinEq([4, <<34, 92>>], BinString).
 
 encode_utf8_string_test() ->
-  S = xmerl_ucs:to_utf8("Avro √§r popul√§r"),
-  BinString = encode_value(avro_primitive:string(S)),
-  ?assertBinEq([42, <<65,118,114,111,32,195,131,194,164,114,32,
-                      112,111,112,117,108,195,131,194,164,114>>], BinString).
+  S = unicode:characters_to_binary("Avro ‰r popul‰r", latin1, utf8),
+  BinString = encode_value(avro_primitive:string(binary_to_list(S))),
+  ?assertBinEq([34, "Avro ", [195,164], "r popul", [195,164], "r"], BinString).
 
 encode_record_test() ->
   BinRecord = encode_value(sample_record()),

--- a/src/avro_json_decoder.erl
+++ b/src/avro_json_decoder.erl
@@ -440,7 +440,8 @@ parse_map({struct, Attrs}, Type, ExtractFun, IsWrapped) ->
 parse_union(null = Value, Type, ExtractFun, IsWrapped) ->
   %% Union values specified as null
   parse_union_ex(?AVRO_NULL, Value, Type, ExtractFun, IsWrapped);
-parse_union({struct, [{ValueTypeNameBin, Value}]}, Type, ExtractFun, IsWrapped) ->
+parse_union({struct, [{ValueTypeNameBin, Value}]},
+            Type, ExtractFun, IsWrapped) ->
   %% Union value specified as {"type": <value>}
   ValueTypeName = binary_to_list(ValueTypeNameBin),
   parse_union_ex(ValueTypeName, Value, Type, ExtractFun, IsWrapped);

--- a/src/avro_json_encoder.erl
+++ b/src/avro_json_encoder.erl
@@ -403,8 +403,8 @@ encode_string_with_quoting_test() ->
     ?assertEqual("\"\\\"\\\\\"", to_string(Json)).
 
 encode_utf8_string_test() ->
-    S = xmerl_ucs:to_utf8("Avro är populär"),
-    Json = encode_value(avro_primitive:string(S)),
+    S = unicode:characters_to_binary("Avro är populär", latin1, utf8),
+    Json = encode_value(avro_primitive:string(binary_to_list(S))),
     ?assertEqual("\"Avro " ++ [195,164] ++ "r popul"++ [195,164] ++ "r\"",
                  to_string(Json)).
 

--- a/src/erlavro.app.src
+++ b/src/erlavro.app.src
@@ -1,7 +1,7 @@
 {application, erlavro,
  [
   {description, "Apache Avro support for Erlang"},
-  {vsn, "1.4.0"},
+  {vsn, "1.4.1"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
the files are created and saved with utf8 encoding.
meaning the strings literals are already utf8 encoded.

changed file encoding to latin1, and fixed the utf8 bytes to 'expect' in the test cases.