### PR TITLE
support wrapped encode result for all types

### DIFF
--- a/include/avro_internal.hrl
+++ b/include/avro_internal.hrl
@@ -39,6 +39,19 @@
 
 -define(AVRO_SCHEMA_LOOKUP_FUN(Store), avro_schema_store:to_lookup_fun(Store)).
 
+-define(AVRO_ENCODED_VALUE_JSON(Type, Value),
+        ?AVRO_VALUE(Type, {json, Value})).
+-define(AVRO_ENCODED_VALUE_BINARY(Type, Value),
+        ?AVRO_VALUE(Type, {binary, Value})).
+
+%% Throw an exception in case the value is already encoded.
+-define(ASSERT_AVRO_VALUE(VALUE),
+        case VALUE of
+          {json, _}   -> erlang:throw({value_already_encoded, VALUE});
+          {binary, _} -> erlang:throw({value_already_encoded, VALUE});
+          _           -> ok
+        end).
+
 -endif.
 
 %%%_* Emacs ====================================================================

--- a/include/erlavro.hrl
+++ b/include/erlavro.hrl
@@ -245,20 +245,10 @@
 
 -type avro_encoding() :: avro_json | avro_binary.
 
--define(AVRO_ENCODED_VALUE_JSON(Type, Value), ?AVRO_VALUE(Type, {json, Value})).
--define(AVRO_ENCODED_VALUE_BINARY(Type, Value), ?AVRO_VALUE(Type, {binary, Value})).
-
 %% avro_encoded_value() can be used as a nested inner value of
 %% a parent avor_value(), but can not be used for further update or
 %% inspection using APIs in avro_xxx modules.
 -type avro_encoded_value() :: #avro_value{}.
-
-%% Throw an exception in case the value is already encoded.
--define(ASSERT_AVRO_VALUE(VALUE),
-        case VALUE of
-          {json, _} -> erlang:throw({value_already_encoded, VALUE});
-          _         -> ok
-        end).
 
 %% Decoder hook is a function to be evaluated when decoding:
 %% 1. primitives

--- a/src/avro_binary_encoder.erl
+++ b/src/avro_binary_encoder.erl
@@ -75,6 +75,8 @@ encode_value(Union) when ?AVRO_IS_UNION_VALUE(Union) ->
 encode(Store, TypeName, Value) when not is_function(Store) ->
   Lkup = ?AVRO_SCHEMA_LOOKUP_FUN(Store),
   encode(Lkup, TypeName, Value);
+encode(_, _, Value) when ?IS_AVRO_VALUE(Value) ->
+  encode_value(Value);
 encode(Lkup, TypeName, Value) when ?IS_NAME(TypeName) ->
   encode(Lkup, Lkup(TypeName), Value);
 encode(_Lkup, Type, Value) when ?AVRO_IS_PRIMITIVE_TYPE(Type) ->

--- a/src/avro_json_encoder.erl
+++ b/src/avro_json_encoder.erl
@@ -85,6 +85,8 @@ encode(Lkup, TypeOrName, Value) ->
 %%%===================================================================
 
 %% @private
+do_encode(_Lkup, _, Value) when ?IS_AVRO_VALUE(Value) ->
+  encode_value(Value, mochijson3);
 do_encode(Lkup, TypeName, Value) when ?IS_NAME(TypeName) ->
   do_encode(Lkup, Lkup(TypeName), Value);
 do_encode(_Lkup, Type, Value) when ?AVRO_IS_PRIMITIVE_TYPE(Type) ->

--- a/src/erlavro.app.src
+++ b/src/erlavro.app.src
@@ -1,7 +1,7 @@
 {application, erlavro,
  [
   {description, "Apache Avro support for Erlang"},
-  {vsn, "1.9.0"},
+  {vsn, "1.9.1"},
   {registered, []},
   {applications, [
                   kernel,

--- a/test/avro_record_tests.erl
+++ b/test/avro_record_tests.erl
@@ -147,7 +147,7 @@ cast_by_aliases_test() ->
 new_encoded_test() ->
   Type = avro_record:type("Test",
     [ avro_record:define_field("field1", avro_primitive:long_type())
-      , avro_record:define_field("field2", avro_primitive:string_type())
+    , avro_record:define_field("field2", avro_primitive:string_type())
     ],
     [ {namespace, "name.space"}
     ]),


### PR DESCRIPTION
This is to allow encoding different parts of a complex value and put together to compose the parent wrapper object.
e.g. for a big record, the fields might be encoded in other worker processes and collected by a coordinator process to finally compose the wrapper record (or sometimes a big union).
