### PR TITLE
Allow tagging union values for encode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ ebin/*.app
 ebin/*.beam
 .eunit
 /lib/
+deps/
 /.rebar/
 doc/
 .idea/

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ License: Apache License 2.0
 | enum | `string()` | `string()` | `atom()` or `binary()` is not supported so far |
 | fixed | `binary()` | `binary()` | |
 | array | `list()` | `list()` | |
-| map | `[{Key::string(), Value::in()}]` | `[{Key::string(), Value::out()}]` | Will support `atom() | binary()` as Key in 2.0 |
-| record | `[{FieldName::string(), FieldValue::in()}]` | `[{FieldName::string(), FiledValue::out()}]` | Will support `atom()` as `FiledName` for encoder in 2.0; User may implement decoder hook to get `FieldName` decoded as `atom()` |
+| map | `[{Key::string(), Value::in()}]` | `[{Key::string(), Value::out()}]` | Will support `atom() | binary()` as Key for encoder in 2.0 |
+| record | `[{FieldName::string(), FieldValue::in()}]` | `[{FieldName::string(), FiledValue::out()}]` | Will support `atom()` as `FiledName` for encoder in 2.0 |
 | union | `in() | {Tag::string(), in()}`  | `out() | {Tag::string(), out()}` | Tag is the type name, See notes about unions below |
 
 Where `in()` and `out()` refer to the input and output type specs recursively

--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ Dependencies: jsonx and mochijson3 (see rebar.config).
 
 [![Build Status](https://travis-ci.org/klarna/erlavro.svg?branch=master)](https://travis-ci.org/klarna/erlavro)
 
+# Avro Type and Erlang Spec mapping
+
+| Avro Type | Erlang Spec | Notes |
+| --- | --- | --- |
+| null | `null` | `undefined` is not accepted by encoder, and `null` is not converted to `undefined` by decoder |
+| boolean | `boolean() \| 0 \| 1` | |
+| int | `-2147483648..2147483647` | |
+| long | `-9223372036854775808..9223372036854775807` | |
+| float | `integer() | float()` | |
+| double | `integer() | float()` | |
+| bytes | `binary()` | |
+| string | `string()` | `binary()` is not supported so far |
+| enum | `string()` | `atom()` or `binary()` is not supported so far |
+| array | `list()` | |
+| map | `[string(), term()]` | `map()` is not supported so far |
+| fixed | `binary()` | |
+| record | `[{FieldName :: string(), FieldValue :: term()}]` | `map()` or `atom()` as `FiledName` is not supported so far |
+| union | `term() | {Tag :: string(), term()}`  | Tag is the type name |
+
 # Examples
 
 ## Load Avro Schema file(s) (demonstrating in Erlang shell)
@@ -137,29 +156,6 @@ JSON to expect:
   ] = Decoder(MyArray, Bin),
   ok.
 ```
-
-# Avro Type and Erlang Spec mapping
-
-* null: `null`
-  `undefined` is not accepted by encoder, and `null` is not converted to `undefined` by decoder
-* boolean: `boolean() | 0 | 1`
-* int: `-2147483648..2147483647`
-* long: `-9223372036854775808..9223372036854775807`
-* float: `integer() | float()`
-* double: `integer() | float()`
-* bytes: `binary()`
-* string: `string()`
-  `binary()` is not supported so far
-* enum: `string()`
-  `atom()` or `binary()` is not supported so far
-* array: `list()`
-* map: `[string(), term()]`
-  `map()` is not supported so far
-* fixed: `binary()`
-* record: `[{FieldName :: string(), FieldValue :: term()}]`
-  `map()` or `atom()` as `FiledName` is not supported so far
-* union: `term() | {Tag :: string(), term()}`
-  where Tag is the type name
 
 # Decoder Hooks
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dependencies: jsonx and mochijson3 (see rebar.config).
 | float | `integer() | float()` | `float()` | |
 | double | `integer() | float()` | `float()` | |
 | bytes | `binary()` | `binary()` | |
-| string | `[byte()] | binary()` | `[byte()]` | NOT `iolist()` for encoder, will change decoder output to `binary()` in 2.0 |
+| string | `[byte()] | binary()` | `[byte()]` | NOT `iolist()` for encoder. Will change decoder output to `binary()` in 2.0 |
 | enum | `string()` | `string()` | `atom()` or `binary()` is not supported so far |
 | array | `list()` | `list()` | |
 | map | `[string(), term()]` | `[string(), term()]` | `map()` is not supported so far |
@@ -33,15 +33,15 @@ Dependencies: jsonx and mochijson3 (see rebar.config).
 
 ## Important Notes about Unicode Strings
 
-The binary encoder/decoder will respec whatever is given in the input (bytes). 
+The binary encoder/decoder will respect whatever is given in the input (bytes). 
 i.e. The encoder will NOT try to be smart and encode the input `string()` to utf8 (or whatsoever), 
 and the decoder will not try to decode the input `binary()` to unicode char list. 
 
-The encoder user should make sure the input is a `[byte()] | binary()`, 
+The encoder caller should make sure the input is a `[byte()] | binary()`, 
 not a unicode character list which possibly has some non-ascii code points.
 
-For historical reason, the JSON encoder will try to encode the string in utf8 in output JSON object. 
-And the JSON decoder will try to validate the input strings as utf8 -- as it's the how mochijson3 implemented
+For historical reason, the JSON encoder will try to encode the string in utf8. 
+And the JSON decoder will try to validate the input strings as utf8 -- as it's how mochijson3 implemented
 
 # Examples
 
@@ -178,7 +178,7 @@ Hooks can be used to:
 * Debug. e.g. `avro_decoer_hooks:print_debug_trace/2` gives you a hook which can print decode history and stack upon failure
 * Monkey patch corrupted data.
 
-The default decoder hook does nothing by passing along the decode calls:
+The default decoder hook does nothing but just passing through the decode call:
 
 ```
 fun(__Type__, __SubNameOrId__, Data, DecodeFun) ->

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Dependencies: jsonx and mochijson3 (see rebar.config).
 
 # Avro Type and Erlang Spec Mapping
 
-| Avro | To Encoder | From Decoder | Notes |
+| Avro | Encoder Input | Decoder Output | Notes |
 | --- | --- | --- | --- |
 | null | `null` | `null` | `undefined` is not accepted by encoder, and `null` is not converted to `undefined` by decoder |
 | boolean | `boolean() | 0 | 1` | `boolean()` | |

--- a/README.md
+++ b/README.md
@@ -168,11 +168,11 @@ JSON to expect:
 # Decoder Hooks
 
 Decoder hook is an anonymous function to be evaluated by the JSON or binary decoder to amend data before and/or after decoding. 
-Hooks can be used to:
+Some hook use cases:
 
-* Fast-skip undesired data fields of records or undesired data of big maps etc.
-* Debug. e.g. `avro_decoer_hooks:print_debug_trace/2` gives you a hook which can print decode history and stack upon failure
-* Monkey patch corrupted data.
+* For JSON decoder, fast-skip undesired data fields in records or keys in maps.
+* Debugging. e.g. `avro_decoer_hooks:print_debug_trace/2` gives you a hook which can print decode history and stack upon failure
+* Monkey patching corrupted data.
 
 The default decoder hook does nothing but just passing through the decode call:
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ JSON to expect:
   Hook = avro_decoder_hooks:tag_unions(),
   Decoder = avro:get_decoder(Lkup, [{hook, Hook} | CodecOptions]),
   [ {"my.com.MyRecord1", [{"f1", null}, {"f2", "str1"}]}
-  , {"my.com.MyRecord2", [{"f1", "str2"}, {"f2", {"int", 2}}]}
+  , {"my.com.MyRecord2", [{"f1", "str2"}, {"f2", 2}]}
   ] = Decoder(Bin, MyArray),
   ok.
 ```

--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@ Current version implements Apache Avro 1.7.5 specification.
 
 License: Apache License 2.0
 
-# Compilation
-
-   make
-
-Dependencies: jsonx and mochijson3 (see rebar.config).
-
 [![Build Status](https://travis-ci.org/klarna/erlavro.svg?branch=master)](https://travis-ci.org/klarna/erlavro)
 
 # Avro Type and Erlang Spec Mapping

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Dependencies: jsonx and mochijson3 (see rebar.config).
 | enum | `string()` | `string()` | `atom()` or `binary()` is not supported so far |
 | fixed | `binary()` | `binary()` | |
 | array | `list()` | `list()` | |
-| map | `[{Key::string(), Value::term()}]` | `[{Key::string(), Value::term()}]` | `map()` is not supported so far |
-| record | `[{FieldName::string(), FieldValue::term()}]` | `[{FieldName::string(), FiledValue::term()}]` | `map()` or `atom()` as `FiledName` is not supported so far |
-| union | `term() | {Tag::string(), term()}`  | `term() | {Tag::string(), term()}` | Tag is the type name, See notes about unions below |
+| map | `[{Key::string(), Value::in()}]` | `[{Key::string(), Value::out()}]` | `map()` is not supported so far |
+| record | `[{FieldName::string(), FieldValue::in()}]` | `[{FieldName::string(), FiledValue::out()}]` | `map()` or `atom()` as `FiledName` is not supported so far |
+| union | `in() | {Tag::string(), in()}`  | `out() | {Tag::string(), out()}` | Tag is the type name, See notes about unions below |
+
+Where `in()` and `out()` refer to the input and output type specs recursively
 
 ## Important Notes about Unicode Strings
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ See `priv/interop.avsc` for avro schema definition.
  {"recordField",
   [{"label","blah"},
    {"children",[[{"label","inner"},{"children",[]}]]}]}]
-3> Encoder = avro:get_encoder(Store, []).
-4> Decoder = avro:get_decoder(Store, []).
-5> Encoded = iolist_to_binary(Encoder(Term, "org.apache.avro.Interop")).
-6> Term =:= Decoder(Encoded, "org.apache.avro.Interop").
+3> Encoder = avro:make_encoder(Store, []).
+4> Decoder = avro:make_decoder(Store, []).
+5> Encoded = iolist_to_binary(Encoder("org.apache.avro.Interop", Term)).
+6> Term =:= Decoder("org.apache.avro.Interop", Encoded).
 true
 ```
 
@@ -56,13 +56,13 @@ true
       "MyRecord",
       [avro_record:define_field("f1", avro_primitive:int_type()),
        avro_record:define_field("f2", avro_primitive:string_type())],
-      [{namespace, "my.com"}]),
+      [{namespace, "com.example"}]),
   Store = avro_schema_store:add_type(MyRecordType, avro_schema_store:new([])),
-  Encoder = avro:get_encoder(Store, []),
-  Decoder = avro:get_decoder(Store, []),
+  Encoder = avro:make_encoder(Store, []),
+  Decoder = avro:make_decoder(Store, []),
   Term = [{"f1", 1},{"f2","my string"}],
-  Bin = Encoder(Term, "my.com.MyRecord"),
-  Term = Decoder(Bin, "my.com.MyRecord"),
+  Bin = Encoder("com.example.MyRecord", Term),
+  Term = Decoder("com.example.MyRecord", Bin),
   ok.
 ```
 
@@ -74,13 +74,13 @@ true
       "MyRecord",
       [avro_record:define_field("f1", avro_primitive:int_type()),
        avro_record:define_field("f2", avro_primitive:string_type())],
-      [{namespace, "my.com"}]),
+      [{namespace, "com.example"}]),
   Store = avro_schema_store:add_type(MyRecordType, avro_schema_store:new([])),
-  Encoder = avro:get_encoder(Store, [{encoding, avro_json}]),
-  Decoder = avro:get_decoder(Store, [{encoding, avro_json}]),
+  Encoder = avro:make_encoder(Store, [{encoding, avro_json}]),
+  Decoder = avro:make_decoder(Store, [{encoding, avro_json}]),
   Term = [{"f1", 1},{"f2", "my string"}],
-  JSON = Encoder(Term, "my.com.MyRecord"),
-  Term = Decoder(JSON, "my.com.MyRecord"),
+  JSON = Encoder("com.example.MyRecord", Term),
+  Term = Decoder("com.example.MyRecord", JSON),
   io:put_chars(user, JSON),
   ok.
 ```
@@ -102,13 +102,13 @@ JSON to expect:
       "MyRecord1",
       [avro_record:define_field("f1", NullableInt),
        avro_record:define_field("f2", avro_primitive:string_type())],
-      [{namespace, "my.com"}]),
+      [{namespace, "com.example"}]),
   MyRecordType2 =
     avro_record:type(
       "MyRecord2",
       [avro_record:define_field("f1", avro_primitive:string_type()),
        avro_record:define_field("f2", NullableInt)],
-      [{namespace, "my.com"}]),
+      [{namespace, "com.example"}]),
   MyUnion = avro_union:type([MyRecordType1, MyRecordType2]),
   MyArray = avro_array:type(MyUnion),
   Lkup = fun(_) -> erlang:error("not expecting type lookup because "
@@ -116,25 +116,25 @@ JSON to expect:
                                 "i.e. no name references") end,
   %% Encode Records with type info wrapped
   %% so they can be used as a drop-in part of wrapper object
-  WrappedEncoder = avro:get_encoder(Lkup, [wrapped | CodecOptions]),
+  WrappedEncoder = avro:make_encoder(Lkup, [wrapped | CodecOptions]),
   T1 = [{"f1", null}, {"f2", "str1"}],
   T2 = [{"f1", "str2"}, {"f2", 2}],
   %% Encode the records with type info wrapped
-  R1 = WrappedEncoder(T1, MyRecordType1),
-  R2 = WrappedEncoder(T2, MyRecordType2),
+  R1 = WrappedEncoder(MyRecordType1, T1),
+  R2 = WrappedEncoder(MyRecordType2, T2),
   %% Tag the union values for better encoding performance
-  U1 = {"my.com.MyRecord1", R1},
-  U2 = {"my.com.MyRecord2", R2},
+  U1 = {"com.example.MyRecord1", R1},
+  U2 = {"com.example.MyRecord2", R2},
   %% This encoder returns iodata result without type info wrapped
-  BinaryEncoder = avro:get_encoder(Lkup, CodecOptions),
+  BinaryEncoder = avro:make_encoder(Lkup, CodecOptions),
   %% Construct the array from encoded elements
-  Bin = iolist_to_binary(BinaryEncoder([U1, U2], MyArray)),
+  Bin = iolist_to_binary(BinaryEncoder(MyArray, [U1, U2])),
   %% Tag the decoded values
   Hook = avro_decoder_hooks:tag_unions(),
-  Decoder = avro:get_decoder(Lkup, [{hook, Hook} | CodecOptions]),
-  [ {"my.com.MyRecord1", [{"f1", null}, {"f2", "str1"}]}
-  , {"my.com.MyRecord2", [{"f1", "str2"}, {"f2", 2}]}
-  ] = Decoder(Bin, MyArray),
+  Decoder = avro:make_decoder(Lkup, [{hook, Hook} | CodecOptions]),
+  [ {"com.example.MyRecord1", [{"f1", null}, {"f2", "str1"}]}
+  , {"com.example.MyRecord2", [{"f1", "str2"}, {"f2", 2}]}
+  ] = Decoder(MyArray, Bin),
   ok.
 ```
 

--- a/README.md
+++ b/README.md
@@ -140,10 +140,12 @@ JSON to expect:
 
 ## Decoder Hooks
 
-Decoder hook is an anonymous function to be evaluated by the JSON or binary decoder to amend either schmea or data (input or output).
+Decoder hook is an anonymous function to be evaluated by the JSON or binary decoder to amend schmea and|or data before and|or after decoding.
+
 * A hook can be used to fast-skip undesired data fields of records or undesired data of big maps etc.
 * A hook can be used for debug. e.g. `avro_decoer_hooks:make_binary_decoder_debug_hook/2' gives you a hook which can print decode history and stack upon failure
 * A hook can also be used as a monkey patch to fix some corrupted data.
+
 Find the examples in `avro_decoder_hooks.erl'
 
 ## NOTEs About Unions

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ JSON to expect:
   %% Construct the array from encoded elements
   Bin = iolist_to_binary(BinaryEncoder([U1, U2], MyArray)),
   %% Tag the decoded values
-  Hook = avro_decoder_hooks:tag_unions_fun(),
+  Hook = avro_decoder_hooks:tag_unions(),
   Decoder = avro:get_decoder(Lkup, [{hook, Hook} | CodecOptions]),
   [ {"my.com.MyRecord1", [{"f1", null}, {"f2", "str1"}]}
   , {"my.com.MyRecord2", [{"f1", "str2"}, {"f2", {"int", 2}}]}
@@ -144,7 +144,7 @@ Decoder hook is an anonymous function to be evaluated by the JSON or binary deco
 Hooks can be used to:
 
 * Fast-skip undesired data fields of records or undesired data of big maps etc.
-* Debug. e.g. `avro_decoer_hooks:make_binary_decoder_debug_hook/2` gives you a hook which can print decode history and stack upon failure
+* Debug. e.g. `avro_decoer_hooks:print_debug_trace/2` gives you a hook which can print decode history and stack upon failure
 * Mmonkey patch corrupted data.
 
 Find the examples in `avro_decoder_hooks.erl`
@@ -159,7 +159,7 @@ efficient when the union is relatively big.
 
 ### Union Values Are Decoded Without Tags by Default
 
-However, you may use the decoder hook `avro_decoer_hooks:tag_unions_fun/0`
+However, you may use the decoder hook `avro_decoer_hooks:tag_unions/0`
 to have the decoded values tagged.
 
 ## Object container file encoding/decoding

--- a/README.md
+++ b/README.md
@@ -141,26 +141,26 @@ JSON to expect:
 ## Decoder Hooks
 
 Decoder hook is an anonymous function to be evaluated by the JSON or binary decoder to amend schmea and|or data before and|or after decoding.
+Hooks can be used to:
 
-* A hook can be used to fast-skip undesired data fields of records or undesired data of big maps etc.
-* A hook can be used for debug. e.g. `avro_decoer_hooks:make_binary_decoder_debug_hook/2' gives you a hook which can print decode history and stack upon failure
-* A hook can also be used as a monkey patch to fix some corrupted data.
+* Fast-skip undesired data fields of records or undesired data of big maps etc.
+* Debug. e.g. `avro_decoer_hooks:make_binary_decoder_debug_hook/2' gives you a hook which can print decode history and stack upon failure
+* Mmonkey patch corrupted data.
 
 Find the examples in `avro_decoder_hooks.erl'
 
 ## NOTEs About Unions
 
-### Union Values Are Better to be Encoded With Tags
+### Union Values Should be Tagged for Better Encoding Performance
 
-In case a union value is not tagged with a type name, the encoder will have to 
+In case a union value is NOT tagged with a type name, the encoder will have to 
 try to loop over all union members to encode until succeed. This is not quite 
-efficent when the union is relatively big
+efficient when the union is relatively big.
 
 ### Union Values Are Decoded Without Tags by Default
 
-However, you may use the anonymous functions returned from 
-`avro_decoer_hooks:tag_unions_fun/0' as a decode hook to get 
-the decoded values tagged.
+However, you may use the decoder hook `avro_decoer_hooks:tag_unions_fun/0' 
+to have the decoded values tagged.
 
 ## Object container file encoding/decoding
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ See `priv/interop.avsc` for avro schema definition.
 3> Encoder = avro:get_encoder(Store, []).
 4> Decoder = avro:get_decoder(Store, []).
 5> Encoded = iolist_to_binary(Encoder(Term, "org.apache.avro.Interop")).
-6> Term = Decoder("org.apache.avro.Interop", Encoded).
+6> Term =:= Decoder(Encoded, "org.apache.avro.Interop").
+true
 ```
 
 ## Define avro schema using erlavro APIs

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ Dependencies: jsonx and mochijson3 (see rebar.config).
 | --- | --- | --- | --- |
 | null | `null` | `null` | `undefined` is not accepted by encoder, and `null` is not converted to `undefined` by decoder |
 | boolean | `boolean() | 0 | 1` | `boolean()` | |
-| int | `-2147483648..2147483647` | `integer()` | |
-| long | `-9223372036854775808..9223372036854775807` | `integer()` | |
+| int | `integer()` | `integer()` | `-2147483648..2147483647` |
+| long | `integer()` | `integer()` | `-9223372036854775808..9223372036854775807` |
 | float | `integer() | float()` | `float()` | |
 | double | `integer() | float()` | `float()` | |
 | bytes | `binary()` | `binary()` | |
 | string | `[byte()] | binary()` | `[byte()]` | NOT `iolist()` for encoder. Will change decoder output to `binary()` in 2.0 |
 | enum | `string()` | `string()` | `atom()` or `binary()` is not supported so far |
-| array | `list()` | `list()` | |
-| map | `[string(), term()]` | `[string(), term()]` | `map()` is not supported so far |
 | fixed | `binary()` | `binary()` | |
+| array | `list()` | `list()` | |
+| map | `[{Key::string(), Value::term()}]` | `[{Key::string(), Value::term()}]` | `map()` is not supported so far |
 | record | `[{FieldName::string(), FieldValue::term()}]` | `[{FieldName::string(), FiledValue::term()}]` | `map()` or `atom()` as `FiledName` is not supported so far |
 | union | `term() | {Tag::string(), term()}`  | `term() | {Tag::string(), term()}` | Tag is the type name, See notes about unions below |
 
@@ -223,8 +223,8 @@ Therefore we are recommending the `Tagged` way, because it'll help the encoder t
 
 ### Union Values Are Decoded Without Tags by Default
 
-A bit contradicting to the recommended union encoding, the union members are NOT tagged by decoder BY DEFAULT. 
-Because we believe the use case of tagged unions in decoder output is not as common 
+A bit contradicting to the recommended union encoding, the decoded values are NOT tagged by DEFAULT. 
+Because we believe the use case of tagged unions in decoder output is not as common. 
 You may use the decoder hook `avro_decoer_hooks:tag_unions/0` to have the decoded values tagged. 
 NOTE: only named complex types are tagged by this hook, you can of course write your own hook for a different tagging behaviour.
 
@@ -232,11 +232,7 @@ NOTE: only named complex types are tagged by this hook, you can of course write 
 
 See `avro_ocf.erl` for details
 
-
 # TODOs
-
-This version of library supports only subset of all functionality.
-What things should be done:
 
 1. Full support for avro 1.8
 2. Support `atom() | binary()` as type names

--- a/README.md
+++ b/README.md
@@ -140,12 +140,12 @@ JSON to expect:
 
 ## Decoder Hooks
 
-Decoder hook is an anonymous function to be evaluated by the JSON or binary decoder to amend schmea and/or data before and/or after decoding.
+Decoder hook is an anonymous function to be evaluated by the JSON or binary decoder to amend schmea and/or data before and/or after decoding. 
 Hooks can be used to:
 
 * Fast-skip undesired data fields of records or undesired data of big maps etc.
 * Debug. e.g. `avro_decoer_hooks:print_debug_trace/2` gives you a hook which can print decode history and stack upon failure
-* Mmonkey patch corrupted data.
+* Monkey patch corrupted data.
 
 Find the examples in `avro_decoder_hooks.erl`
 
@@ -159,7 +159,7 @@ efficient when the union is relatively big.
 
 ### Union Values Are Decoded Without Tags by Default
 
-However, you may use the decoder hook `avro_decoer_hooks:tag_unions/0`
+However, you may use the decoder hook `avro_decoer_hooks:tag_unions/0` 
 to have the decoded values tagged.
 
 ## Object container file encoding/decoding

--- a/include/avro_internal.hrl
+++ b/include/avro_internal.hrl
@@ -39,6 +39,19 @@
 
 -define(AVRO_SCHEMA_LOOKUP_FUN(Store), avro_schema_store:to_lookup_fun(Store)).
 
+-define(AVRO_ENCODED_VALUE_JSON(Type, Value),
+        ?AVRO_VALUE(Type, {json, Value})).
+-define(AVRO_ENCODED_VALUE_BINARY(Type, Value),
+        ?AVRO_VALUE(Type, {binary, Value})).
+
+%% Throw an exception in case the value is already encoded.
+-define(ASSERT_AVRO_VALUE(VALUE),
+        case VALUE of
+          {json, _}   -> erlang:throw({value_already_encoded, VALUE});
+          {binary, _} -> erlang:throw({value_already_encoded, VALUE});
+          _           -> ok
+        end).
+
 -endif.
 
 %%%_* Emacs ====================================================================

--- a/include/avro_internal.hrl
+++ b/include/avro_internal.hrl
@@ -19,6 +19,16 @@
 
 -include("erlavro.hrl").
 
+-define(IS_PRIMITIVE_NAME(N),
+        (N =:= ?AVRO_NULL    orelse
+         N =:= ?AVRO_BOOLEAN orelse
+         N =:= ?AVRO_INT     orelse
+         N =:= ?AVRO_LONG    orelse
+         N =:= ?AVRO_STRING  orelse
+         N =:= ?AVRO_FLOAT   orelse
+         N =:= ?AVRO_DOUBLE  orelse
+         N =:= ?AVRO_BYTES)).
+
 -define(IS_AVRO_TYPE(T), is_tuple(T)).
 -define(IS_NAME(N), (is_list(N))).
 -define(NAMESPACE_NONE, "").

--- a/include/erlavro.hrl
+++ b/include/erlavro.hrl
@@ -245,20 +245,10 @@
 
 -type avro_encoding() :: avro_json | avro_binary.
 
--define(AVRO_ENCODED_VALUE_JSON(Type, Value), ?AVRO_VALUE(Type, {json, Value})).
--define(AVRO_ENCODED_VALUE_BINARY(Type, Value), ?AVRO_VALUE(Type, {binary, Value})).
-
 %% avro_encoded_value() can be used as a nested inner value of
 %% a parent avor_value(), but can not be used for further update or
 %% inspection using APIs in avro_xxx modules.
 -type avro_encoded_value() :: #avro_value{}.
-
-%% Throw an exception in case the value is already encoded.
--define(ASSERT_AVRO_VALUE(VALUE),
-        case VALUE of
-          {json, _} -> erlang:throw({value_already_encoded, VALUE});
-          _         -> ok
-        end).
 
 %% Decoder hook is a function to be evaluated when decoding:
 %% 1. primitives

--- a/include/erlavro.hrl
+++ b/include/erlavro.hrl
@@ -250,39 +250,6 @@
 %% inspection using APIs in avro_xxx modules.
 -type avro_encoded_value() :: #avro_value{}.
 
-%% Decoder hook is a function to be evaluated when decoding:
-%% 1. primitives
-%% 2. each field/element of complex types.
-%%
-%% A hook fun can be used to fast skipping undesired data fields of records
-%% or undesired data of big maps etc.
-%% For example, to dig out only the field named "MyField" in "MyRecord", the
-%% hook may probably look like:
-%%
-%% fun(Type, SubNameOrIndex, Data, DecodeFun) ->
-%%      case {avro:get_type_fullname(Type), SubNameOrIndex} of
-%%        {"MyRecord.example.com", "MyField"} ->
-%%          DecodeFun(Data);
-%%        {"MyRecord.example.com", _OtherFields} ->
-%%          ignored;
-%%        _OtherType ->
-%%          DecodeFun(Data)
-%%      end
-%% end.
-%%
-%% A hook fun can be used for debug. For example, below hook should print
-%% the decoding stack along the decode function traverses through the bytes.
-%%
-%% fun(Type, SubNameOrIndex, Data, DecodeFun) ->
-%%      SubInfo = case is_integer(SubNameOrIndex) of
-%%                  true  -> integer_to_list(SubNameOrIndex);
-%%                  false -> SubNameOrIndex
-%%                end,
-%%      io:format("~s.~s\n", [avro:get_type_name(Type), SubInfo]),
-%%      DecodeFun(Data)
-%% end
-%%
-%% A hook can also be used as a dirty patch to fix some corrupted data.
 -type dec_in() :: term(). %% binary() | decoded json struct / raw value
 -type dec_out() :: term(). %% decoded raw value or #avro_value{}
 
@@ -293,5 +260,10 @@
 %% By default, the hook fun does nothing else but calling the decode function.
 -define(DEFAULT_DECODER_HOOK,
         fun(__Type__, __SubNameOrId__, Data, DecodeFun) -> DecodeFun(Data) end).
-
 -endif.
+
+%%%_* Emacs ====================================================================
+%%% Local Variables:
+%%% allout-layout: t
+%%% erlang-indent-level: 2
+%%% End:

--- a/rebar.config
+++ b/rebar.config
@@ -5,8 +5,7 @@
                        , {platform_define, "^(?!R)", otp_17_or_above}
                        , {d,'NOTEST'}
                        ]}.
-{deps_dir,             "lib"}.
-{lib_dirs,             ["lib"]}.
+{deps_dir,             "deps"}.
 {cover_enabled,        true}.
 {cover_print_enabled,  true}.
 {cover_export_enabled, true}.

--- a/src/avro.erl
+++ b/src/avro.erl
@@ -50,7 +50,8 @@
         , encode_wrapped/4
         ]).
 
--export_type([ decode_fun/0
+-export_type([ codec_options/0
+             , decode_fun/0
              , encode_fun/0
              , enum_symbol/0
              , fullname/0

--- a/src/avro.erl
+++ b/src/avro.erl
@@ -65,9 +65,9 @@
 
 -type codec_options() :: [proplists:property()].
 -type encode_fun() ::
-        fun((avro_type_or_name(), term()) -> iodata() | avro_value()).
+        fun((term(), avro_type_or_name()) -> iodata() | avro_value()).
 -type decode_fun() ::
-        fun((avro_type_or_name(), binary()) -> term()).
+        fun((binary(), avro_type_or_name()) -> term()).
 
 %% @doc Get encoder function.
 -spec get_encoder(schema_store() | lkup_fun(), codec_options()) ->
@@ -77,16 +77,18 @@ get_encoder(StoreOrLkupFun, Options) ->
   IsWrapped = proplists:get_bool(wrapped, Options),
   case IsWrapped of
     true ->
-      fun(TypeOrName, Value) ->
+      fun(Value, TypeOrName) ->
         ?MODULE:encode_wrapped(StoreOrLkupFun, TypeOrName, Value, Encoding)
       end;
     false ->
-      fun(TypeOrName, Value) ->
+      fun(Value, TypeOrName) ->
         ?MODULE:encode(StoreOrLkupFun, TypeOrName, Value, Encoding)
       end
   end.
 
 %% @doc Get decoder function.
+-spec get_decoder(schema_store() | lkup_fun(), codec_options()) ->
+        decode_fun().
 get_decoder(StoreOrLkupFun, Options) ->
   Encoding = proplists:get_value(encoding, Options, avro_binary),
   Hook = proplists:get_value(hook, Options, ?DEFAULT_DECODER_HOOK),

--- a/src/avro_binary_encoder.erl
+++ b/src/avro_binary_encoder.erl
@@ -178,8 +178,10 @@ bytes(Data) when is_binary(Data) ->
   [long(byte_size(Data)), Data].
 
 %% @private
+string(Data) when is_binary(Data) ->
+  [long(size(Data)), Data];
 string(Data) when is_list(Data) ->
-  [long(length(Data)), list_to_binary(Data)].
+  string(list_to_binary(Data)).
 
 %% @private
 %% ZigZag encode/decode

--- a/src/avro_binary_encoder.erl
+++ b/src/avro_binary_encoder.erl
@@ -75,6 +75,8 @@ encode_value(Union) when ?AVRO_IS_UNION_VALUE(Union) ->
 encode(Store, TypeName, Value) when not is_function(Store) ->
   Lkup = ?AVRO_SCHEMA_LOOKUP_FUN(Store),
   encode(Lkup, TypeName, Value);
+encode(_, _, Value) when ?IS_AVRO_VALUE(Value) ->
+  encode_value(Value);
 encode(Lkup, TypeName, Value) when ?IS_NAME(TypeName) ->
   encode(Lkup, Lkup(TypeName), Value);
 encode(_Lkup, Type, Value) when ?AVRO_IS_PRIMITIVE_TYPE(Type) ->

--- a/src/avro_binary_encoder.erl
+++ b/src/avro_binary_encoder.erl
@@ -75,8 +75,8 @@ encode_value(Union) when ?AVRO_IS_UNION_VALUE(Union) ->
 encode(Store, TypeName, Value) when not is_function(Store) ->
   Lkup = ?AVRO_SCHEMA_LOOKUP_FUN(Store),
   encode(Lkup, TypeName, Value);
-encode(_, _, Value) when ?IS_AVRO_VALUE(Value) ->
-  encode_value(Value);
+encode(_Lkup, Type, #avro_value{type = Type} = V) ->
+  encode_value(V);
 encode(Lkup, TypeName, Value) when ?IS_NAME(TypeName) ->
   encode(Lkup, Lkup(TypeName), Value);
 encode(_Lkup, Type, Value) when ?AVRO_IS_PRIMITIVE_TYPE(Type) ->

--- a/src/avro_decoder_hooks.erl
+++ b/src/avro_decoder_hooks.erl
@@ -95,7 +95,7 @@ print_debug_trace(PrintFun, MaxHistoryLength) ->
   end.
 
 %% @doc This hook prints the type tree with indentation, and the leaf values
-%% to the io-device 'user' is directed.
+%% to the current group leader.
 %% @end
 -spec pretty_print_hist() -> decoder_hook_fun().
 pretty_print_hist() ->
@@ -119,7 +119,7 @@ pretty_print_hist() ->
           _                    -> "\n"
         end
       ],
-    io:format(user, "~s", [ToPrint]),
+    io:format("~s", [ToPrint]),
     _ = put(?PD_PP_INDENTATION, Indentation + 1),
     DecodeResult = DecodeFun(Data),
     ResultToPrint = get_pretty_print_result(DecodeResult),
@@ -263,10 +263,10 @@ get_pretty_print_result(JsonResult) ->
 %% @private
 pretty_print_result(_Sub = [], _Result = [], IndentationStr) ->
   %% print empty array and empty map
-  io:format(user, "~s  []\n", [IndentationStr]);
+  io:format("~s  []\n", [IndentationStr]);
 pretty_print_result(_Sub = [], Result, _IndentationStr) ->
   %% print the value if it's a leaf in the type tree
-  io:format(user, "~1000000p\n", [Result]);
+  io:format("~1000000p\n", [Result]);
 pretty_print_result(_Sub, _Result, _IndentationStr) ->
   ok.
 

--- a/src/avro_decoder_hooks.erl
+++ b/src/avro_decoder_hooks.erl
@@ -26,14 +26,14 @@
 %% A hook can be used to fast-skip undesired data fields of records
 %% or undesired data of big maps etc.
 %% e.g. To dig out only the field named "MyField" in "MyRecord", the
-%% hook may probably look like:
+%% JSON decoder hook may probably look like:
 %%
 %% <pre>
 %% fun(Type, SubNameOrIndex, Data, DecodeFun) ->
 %%      case {avro:get_type_fullname(Type), SubNameOrIndex} of
-%%        {"MyRecord.example.com", "MyField"} ->
+%%        {"com.example.MyRecord", "MyField"} ->
 %%          DecodeFun(Data);
-%%        {"MyRecord.example.com", _OtherFields} ->
+%%        {"com.example.MyRecord", _OtherFields} ->
 %%          ignored;
 %%        _OtherType ->
 %%          DecodeFun(Data)

--- a/src/avro_decoder_hooks.erl
+++ b/src/avro_decoder_hooks.erl
@@ -14,6 +14,7 @@
 %%% KIND, either express or implied.  See the License for the
 %%% specific language governing permissions and limitations
 %%% under the License.
+%%%-------------------------------------------------------------------
 %%%
 %%% @doc This module is a collection of `eravro' supported decoder hooks
 %%
@@ -59,43 +60,51 @@
 %%%-------------------------------------------------------------------
 -module(avro_decoder_hooks).
 
--export([ binary_decoder_debug_trace/2
-        , tag_unions_fun/0
+-export([ tag_unions/0
         , pretty_print_hist/0
+        , print_debug_trace/2
         ]).
 
 -include("avro_internal.hrl").
 
+-define(PD_PP_INDENTATION, '$avro_decoder_pp_indentation').
+-define(PD_DECODER_HIST, '$avro_decoder_hist').
+-define(REASON_TAG, '$hook-raised').
+
 -type count() :: non_neg_integer().
+-type trace_hist_entry() :: {push, _, _} | {pop, _} | pop.
 
 %% @doc By default, decoders do not tag union values.
 %% This hook function is to tag union values with union type names
 %% NOTE: null values are not tagged
 %% @end
--spec tag_unions_fun() -> decoder_hook_fun().
-tag_unions_fun() -> fun tag_unions/4.
+-spec tag_unions() -> decoder_hook_fun().
+tag_unions() -> fun tag_unions/4.
 
-%% @doc This hook is useful when a binary decoder failed on decoding
-%% a binary blob, try to decode it again with this hook to inspect
-%% the decode history and the avro type stack where the failure happened
+%% @doc This hook is useful when a decoder has failed on decoding,
+%% try to decode it again with this hook to inspect the decode history
+%% and the avro type stack where the failure happened
+%% NOTE: Always call this API to retrieve the hook, never save the hook
+%%       and re-use for different decode attempts
 %% @end.
--spec binary_decoder_debug_trace(fun((iodata()) -> ok), count()) ->
-          decoder_hook_fun().
-binary_decoder_debug_trace(PrintFun, MaxHistoryLength) ->
+-spec print_debug_trace(fun((iodata()) -> ok), count()) -> decoder_hook_fun().
+print_debug_trace(PrintFun, MaxHistoryLength) ->
+  ok = erase_hist(),
   fun(T, Sub, Data, DecodeFun) ->
     print_trace_on_failure(T, Sub, Data, DecodeFun, PrintFun, MaxHistoryLength)
   end.
 
 %% @doc Return a function to be used as the decoder hook.
 %% The hook prints the type tree with indentation, and the leaf values
-%% to whichever 'user' io device is directed.
+%% to the io-device 'user' is directed.
 %% @end
 -spec pretty_print_hist() -> decoder_hook_fun().
 pretty_print_hist() ->
+  _ = erase(?PD_PP_INDENTATION),
   fun(T, SubInfo, Data, DecodeFun) ->
     Name = avro:get_type_fullname(T),
     Indentation =
-      case get(avro_decoder_pp_indentation) of
+      case get(?PD_PP_INDENTATION) of
         undefined -> 0;
         Indentati -> Indentati
       end,
@@ -112,7 +121,7 @@ pretty_print_hist() ->
         end
       ],
     io:format(user, "~s", [ToPrint]),
-    _ = put(avro_decoder_pp_indentation, Indentation + 1),
+    _ = put(?PD_PP_INDENTATION, Indentation + 1),
     DecodeResult = DecodeFun(Data),
     ResultToPrint =
       case DecodeResult of
@@ -135,7 +144,7 @@ pretty_print_hist() ->
       true  -> io:format(user, "~1000000p\n", [ResultToPrint]);
       false -> ok
     end,
-    _ = put(avro_decoder_pp_indentation, Indentation),
+    _ = put(?PD_PP_INDENTATION, Indentation),
     DecodeResult
   end.
 
@@ -169,61 +178,71 @@ tag_unions(_T, _SubInfo, DecodeIn, DecodeFun) ->
 maybe_tag("null", Value) -> Value;
 maybe_tag(Name, Value)   -> {Name, Value}.
 
--define(PD_DECODER_HIST, avro_decoder_hist).
--define(REASON_TAG, '$hook-raised').
-
 %% @private
 print_trace_on_failure(T, Sub, Data, DecodeFun, PrintFun, HistCount) ->
   Name = avro:get_type_fullname(T),
-  ok = push_stack(Name, Sub),
+  ok = add_hist({push, Name, Sub}),
   try
-    {Result, Tail} = DecodeFun(Data),
-    Pop = case Sub =:= [] orelse Result =:= [] of
-            true  -> {value, Result}; %% non-complex type or empty array
-            false -> false
-          end,
-    ok = pop_stack(Pop),
-    {Result, Tail}
+    Result = DecodeFun(Data),
+    Value =
+      case Result of
+        {V, Tail} when is_binary(Tail) ->
+          %% binary decoder
+          V;
+        _ ->
+          %% JSON decoder
+          Result
+      end,
+    case Sub =:= [] orelse Value =:= [] of
+      true  -> add_hist({pop, Value}); %% add stack hist with decoded value
+      false -> add_hist(pop)
+    end,
+    Result
   catch C : R when not (is_tuple(R) andalso element(1, R) =:= ?REASON_TAG) ->
+    %% catch only the very first error
     Stack = erlang:get_stacktrace(),
-    ok = print_trace(PrintFun, get_hist(), HistCount),
-    _ = erlang:erase(?PD_DECODER_HIST),
+    ok = print_trace(PrintFun, HistCount),
+    ok = erase_hist(),
     erlang:raise(C, {?REASON_TAG, R}, Stack)
   end.
 
 %% @private
+-spec erase_hist() -> ok.
+erase_hist() ->
+  _ = erlang:erase(?PD_DECODER_HIST),
+  ok.
+
+%% @private
+-spec get_hist() -> ok.
 get_hist() ->
   case erlang:get(?PD_DECODER_HIST) of
     undefined -> [];
     S         -> S
   end.
 
-%% @private
+%% @private Use process dictionary to keep the decoder stack trace.
+-spec add_hist(trace_hist_entry()) -> ok.
 add_hist(NewOp) ->
   erlang:put(?PD_DECODER_HIST, [NewOp | get_hist()]),
   ok.
 
-%% @private
-push_stack(Name, Sub) -> add_hist({push, Name, Sub}).
-
-%% @private
-pop_stack({value, Value}) -> add_hist({pop, Value});
-pop_stack(false)          -> add_hist(pop).
-
-%% @private
-print_trace(PrintFun, Hist, HistCount) ->
-  {Stack, History} =
-    build_stack(lists:reverse(Hist), _Stack = [], _History = [], HistCount),
+%% @private Print decoder trace (stack and history) using the given function.
+print_trace(PrintFun, HistCount) ->
+  Hist = lists:reverse(get_hist()),
+  {Stack, History} = format_trace(Hist, _Stack = [], _History = [], HistCount),
   PrintFun(["avro type stack:\n", Stack, "\n",
             "decode history:\n", History]).
 
-%% @private
--spec build_stack([{push, _, _} | {pop, _} | pop],
-                  list(), iodata(), count()) ->
-        {Stack :: iodata(), Hist:: iodata()}.
-build_stack([], Stack, Hist, _HistCount) ->
+%% @private Format the trace hisotry into printable format.
+%% Return the type stack and last N decode history entries as iodata().
+%% @end
+-spec format_trace(TraceHist :: [trace_hist_entry()],
+                   TypeStack :: [{name(), atom() | string() | integer()}],
+                   FormattedTrace :: iodata(),
+                   MaxHistEntryCount :: count()) -> {iodata(), iodata()}.
+format_trace([], Stack, Hist, _HistCount) ->
   {io_lib:format("~p", [lists:reverse(Stack)]), lists:reverse(Hist)};
-build_stack([{push, Name, Sub} | Rest], Stack, Hist, HistCount) ->
+format_trace([{push, Name, Sub} | Rest], Stack, Hist, HistCount) ->
   Padding = lists:duplicate(length(Stack) * 2, $\s),
   Line = bin([Padding, Name,
               case Sub of
@@ -233,14 +252,14 @@ build_stack([{push, Name, Sub} | Rest], Stack, Hist, HistCount) ->
                 S when is_list(S)    -> [".", S]
               end, "\n"]),
   NewHist = lists:sublist([Line | Hist], HistCount),
-  build_stack(Rest, [{Name, Sub} | Stack], NewHist, HistCount);
-build_stack([{pop, V} | Rest], Stack, Hist, HistCount) ->
+  format_trace(Rest, [{Name, Sub} | Stack], NewHist, HistCount);
+format_trace([{pop, V} | Rest], Stack, Hist, HistCount) ->
   Padding = lists:duplicate(length(Stack) * 2, $\s),
   Line = bin([Padding, io_lib:format("~100000p", [V]), "\n"]),
   NewHist = lists:sublist([Line | Hist], HistCount),
-  build_stack(Rest, tl(Stack), NewHist, HistCount);
-build_stack([pop | Rest], Stack, Hist, HistCount) ->
-  build_stack(Rest, tl(Stack), Hist, HistCount).
+  format_trace(Rest, tl(Stack), NewHist, HistCount);
+format_trace([pop | Rest], Stack, Hist, HistCount) ->
+  format_trace(Rest, tl(Stack), Hist, HistCount).
 
 %% @private
 bin(IoData) -> iolist_to_binary(IoData).

--- a/src/avro_decoder_hooks.erl
+++ b/src/avro_decoder_hooks.erl
@@ -27,7 +27,7 @@
 %% e.g. To dig out only the field named "MyField" in "MyRecord", the
 %% hook may probably look like:
 %%
-%% ```
+%% <pre>
 %% fun(Type, SubNameOrIndex, Data, DecodeFun) ->
 %%      case {avro:get_type_fullname(Type), SubNameOrIndex} of
 %%        {"MyRecord.example.com", "MyField"} ->
@@ -38,12 +38,12 @@
 %%          DecodeFun(Data)
 %%      end
 %% end.
-%% ```
+%% </pre>
 %%
 %% A hook can be used for debug. For example, below hook should print
 %% the decoding stack along the decode function traverses through the bytes.
 %%
-%% ```
+%% <pre>
 %% fun(Type, SubNameOrIndex, Data, DecodeFun) ->
 %%      SubInfo = case is_integer(SubNameOrIndex) of
 %%                  true  -> integer_to_list(SubNameOrIndex);
@@ -52,7 +52,7 @@
 %%      io:format("~s.~s\n", [avro:get_type_name(Type), SubInfo]),
 %%      DecodeFun(Data)
 %% end
-%% ```
+%% </pre>
 %%
 %% A hook can also be used as a monkey patch to fix some corrupted data.
 %%% @end

--- a/src/avro_decoder_hooks.erl
+++ b/src/avro_decoder_hooks.erl
@@ -1,0 +1,252 @@
+%%%-------------------------------------------------------------------
+%%% Copyright (c) 2013-2016 Klarna AB
+%%%
+%%% This file is provided to you under the Apache License,
+%%% Version 2.0 (the "License"); you may not use this file
+%%% except in compliance with the License.  You may obtain
+%%% a copy of the License at
+%%%
+%%%   http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing,
+%%% software distributed under the License is distributed on an
+%%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%%% KIND, either express or implied.  See the License for the
+%%% specific language governing permissions and limitations
+%%% under the License.
+%%%
+%%% @doc This module is a collection of `eravro' supported decoder hooks
+%%
+%% Decoder hook is an anonymous function to be evaluated by
+%% the JSON or binary decoder to amend either schmea or data (input or output).
+%%
+%% For example:
+%%
+%% A hook can be used to fast-skip undesired data fields of records
+%% or undesired data of big maps etc.
+%% e.g. To dig out only the field named "MyField" in "MyRecord", the
+%% hook may probably look like:
+%%
+%% ```
+%% fun(Type, SubNameOrIndex, Data, DecodeFun) ->
+%%      case {avro:get_type_fullname(Type), SubNameOrIndex} of
+%%        {"MyRecord.example.com", "MyField"} ->
+%%          DecodeFun(Data);
+%%        {"MyRecord.example.com", _OtherFields} ->
+%%          ignored;
+%%        _OtherType ->
+%%          DecodeFun(Data)
+%%      end
+%% end.
+%% ```
+%%
+%% A hook can be used for debug. For example, below hook should print
+%% the decoding stack along the decode function traverses through the bytes.
+%%
+%% ```
+%% fun(Type, SubNameOrIndex, Data, DecodeFun) ->
+%%      SubInfo = case is_integer(SubNameOrIndex) of
+%%                  true  -> integer_to_list(SubNameOrIndex);
+%%                  false -> SubNameOrIndex
+%%                end,
+%%      io:format("~s.~s\n", [avro:get_type_name(Type), SubInfo]),
+%%      DecodeFun(Data)
+%% end
+%% ```
+%%
+%% A hook can also be used as a monkey patch to fix some corrupted data.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(avro_decoder_hooks).
+
+-export([ binary_decoder_debug_trace/2
+        , tag_unions_fun/0
+        , pretty_print_hist/0
+        ]).
+
+-include("avro_internal.hrl").
+
+-type count() :: non_neg_integer().
+
+%% @doc By default, decoders do not tag union values.
+%% This hook function is to tag union values with union type names
+%% NOTE: null values are not tagged
+%% @end
+-spec tag_unions_fun() -> decoder_hook_fun().
+tag_unions_fun() -> fun tag_unions/4.
+
+%% @doc This hook is useful when a binary decoder failed on decoding
+%% a binary blob, try to decode it again with this hook to inspect
+%% the decode history and the avro type stack where the failure happened
+%% @end.
+-spec binary_decoder_debug_trace(fun((iodata()) -> ok), count()) ->
+          decoder_hook_fun().
+binary_decoder_debug_trace(PrintFun, MaxHistoryLength) ->
+  fun(T, Sub, Data, DecodeFun) ->
+    print_trace_on_failure(T, Sub, Data, DecodeFun, PrintFun, MaxHistoryLength)
+  end.
+
+%% @doc Return a function to be used as the decoder hook.
+%% The hook prints the type tree with indentation, and the leaf values
+%% to whichever 'user' io device is directed.
+%% @end
+-spec pretty_print_hist() -> decoder_hook_fun().
+pretty_print_hist() ->
+  fun(T, SubInfo, Data, DecodeFun) ->
+    Name = avro:get_type_fullname(T),
+    Indentation =
+      case get(avro_decoder_pp_indentation) of
+        undefined -> 0;
+        Indentati -> Indentati
+      end,
+    IndentationStr = lists:duplicate(Indentation * 2, $\s),
+    ToPrint =
+      [ IndentationStr
+      , Name
+      , case SubInfo of
+          ""                   -> ": ";
+          I when is_integer(I) -> [$., integer_to_list(I), "\n"];
+          S when is_list(S)    -> [$., S, "\n"];
+          B when is_binary(B)  -> [$., B, "\n"];
+          _                    -> "\n"
+        end
+      ],
+    io:format(user, "~s", [ToPrint]),
+    _ = put(avro_decoder_pp_indentation, Indentation + 1),
+    DecodeResult = DecodeFun(Data),
+    ResultToPrint =
+      case DecodeResult of
+        {Result, Tail} when is_binary(Tail) ->
+          %% binary decode result
+          Result;
+        JsonDecodeResult ->
+          case ?IS_AVRO_VALUE(JsonDecodeResult) of
+            true  -> ?AVRO_VALUE_DATA(JsonDecodeResult);
+            false -> JsonDecodeResult
+          end
+      end,
+    %% print empty array and empty map
+    case SubInfo =/= [] andalso ResultToPrint =:= [] of
+      true  -> io:format(user, "~s  []\n", [IndentationStr]);
+      false -> ok
+    end,
+    %% print the value if it's a leaf in the type tree
+    case SubInfo =:= [] of
+      true  -> io:format(user, "~1000000p\n", [ResultToPrint]);
+      false -> ok
+    end,
+    _ = put(avro_decoder_pp_indentation, Indentation),
+    DecodeResult
+  end.
+
+%%%_* Internal functions =======================================================
+
+%% @private
+tag_unions(T, SubInfo, DecodeIn, DecodeFun) when ?AVRO_IS_UNION_TYPE(T) ->
+  Result = DecodeFun(DecodeIn),
+  Tag =
+    case SubInfo of
+      Id when is_integer(Id) ->
+        {ok, ST} = avro_union:lookup_child_type(T, Id),
+        avro:get_type_fullname(ST);
+      Name when ?IS_NAME(Name) ->
+        Name
+    end,
+    case Result of
+      {Value, Tail} when is_binary(Tail) ->
+        %% used as binary decoder hook
+        {maybe_tag(Tag, Value), Tail};
+      Value ->
+        %% used as JSON decoder hook
+        maybe_tag(Tag, Value)
+    end;
+tag_unions(_T, _SubInfo, DecodeIn, DecodeFun) ->
+  %% Not a union, pass through
+  DecodeFun(DecodeIn).
+
+%% @private
+%% never tag null
+maybe_tag("null", Value) -> Value;
+maybe_tag(Name, Value)   -> {Name, Value}.
+
+-define(PD_DECODER_HIST, avro_decoder_hist).
+-define(REASON_TAG, '$hook-raised').
+
+%% @private
+print_trace_on_failure(T, Sub, Data, DecodeFun, PrintFun, HistCount) ->
+  Name = avro:get_type_fullname(T),
+  ok = push_stack(Name, Sub),
+  try
+    {Result, Tail} = DecodeFun(Data),
+    Pop = case Sub =:= [] orelse Result =:= [] of
+            true  -> {value, Result}; %% non-complex type or empty array
+            false -> false
+          end,
+    ok = pop_stack(Pop),
+    {Result, Tail}
+  catch C : R when not (is_tuple(R) andalso element(1, R) =:= ?REASON_TAG) ->
+    Stack = erlang:get_stacktrace(),
+    ok = print_trace(PrintFun, get_hist(), HistCount),
+    _ = erlang:erase(?PD_DECODER_HIST),
+    erlang:raise(C, {?REASON_TAG, R}, Stack)
+  end.
+
+%% @private
+get_hist() ->
+  case erlang:get(?PD_DECODER_HIST) of
+    undefined -> [];
+    S         -> S
+  end.
+
+%% @private
+add_hist(NewOp) ->
+  erlang:put(?PD_DECODER_HIST, [NewOp | get_hist()]),
+  ok.
+
+%% @private
+push_stack(Name, Sub) -> add_hist({push, Name, Sub}).
+
+%% @private
+pop_stack({value, Value}) -> add_hist({pop, Value});
+pop_stack(false)          -> add_hist(pop).
+
+%% @private
+print_trace(PrintFun, Hist, HistCount) ->
+  {Stack, History} =
+    build_stack(lists:reverse(Hist), _Stack = [], _History = [], HistCount),
+  PrintFun(["avro type stack:\n", Stack, "\n",
+            "decode history:\n", History]).
+
+%% @private
+-spec build_stack([{push, _, _} | {pop, _} | pop],
+                  list(), iodata(), count()) ->
+        {Stack :: iodata(), Hist:: iodata()}.
+build_stack([], Stack, Hist, _HistCount) ->
+  {io_lib:format("~p", [lists:reverse(Stack)]), lists:reverse(Hist)};
+build_stack([{push, Name, Sub} | Rest], Stack, Hist, HistCount) ->
+  Padding = lists:duplicate(length(Stack) * 2, $\s),
+  Line = bin([Padding, Name,
+              case Sub of
+                []                   -> "";
+                none                 -> "";
+                I when is_integer(I) -> [".", integer_to_list(I)];
+                S when is_list(S)    -> [".", S]
+              end, "\n"]),
+  NewHist = lists:sublist([Line | Hist], HistCount),
+  build_stack(Rest, [{Name, Sub} | Stack], NewHist, HistCount);
+build_stack([{pop, V} | Rest], Stack, Hist, HistCount) ->
+  Padding = lists:duplicate(length(Stack) * 2, $\s),
+  Line = bin([Padding, io_lib:format("~100000p", [V]), "\n"]),
+  NewHist = lists:sublist([Line | Hist], HistCount),
+  build_stack(Rest, tl(Stack), NewHist, HistCount);
+build_stack([pop | Rest], Stack, Hist, HistCount) ->
+  build_stack(Rest, tl(Stack), Hist, HistCount).
+
+%% @private
+bin(IoData) -> iolist_to_binary(IoData).
+
+%%%_* Emacs ====================================================================
+%%% Local Variables:
+%%% allout-layout: t
+%%% erlang-indent-level: 2
+%%% End:

--- a/src/avro_decoder_hooks.erl
+++ b/src/avro_decoder_hooks.erl
@@ -141,14 +141,14 @@ tag_unions(T, SubInfo, DecodeIn, DecodeFun) when ?AVRO_IS_UNION_TYPE(T) ->
       Name_ when ?IS_NAME(Name_) ->
         Name_
     end,
-    case Result of
-      {Value, Tail} when is_binary(Tail) ->
-        %% used as binary decoder hook
-        {maybe_tag(Name, Value), Tail};
-      Value ->
-        %% used as JSON decoder hook
-        maybe_tag(Name, Value)
-    end;
+  case Result of
+    {Value, Tail} when is_binary(Tail) ->
+      %% used as binary decoder hook
+      {maybe_tag(Name, Value), Tail};
+    Value ->
+      %% used as JSON decoder hook
+      maybe_tag(Name, Value)
+  end;
 tag_unions(_T, _SubInfo, DecodeIn, DecodeFun) ->
   %% Not a union, pass through
   DecodeFun(DecodeIn).

--- a/src/avro_json_decoder.erl
+++ b/src/avro_json_decoder.erl
@@ -511,8 +511,14 @@ parse_union(_, _, _, _, _) ->
   erlang:error(wrong_union_value).
 
 %% @private
-parse_union_ex(ValueTypeName, Value, UnionType,
-               ExtractFun, IsWrapped, Hook) ->
+parse_union_ex(ValueTypeName, Value, UnionType, ExtractFun, IsWrapped, Hook) ->
+  Hook(UnionType, ValueTypeName, Value,
+       fun(In) -> do_parse_union_ex(ValueTypeName, In, UnionType,
+                                    ExtractFun, IsWrapped, Hook) end).
+
+%% @private
+do_parse_union_ex(ValueTypeName, Value, UnionType,
+                  ExtractFun, IsWrapped, Hook) ->
   case avro_union:lookup_child_type(UnionType, ValueTypeName) of
     {ok, ValueType} ->
       ParsedValue = parse(Value, ValueType, ExtractFun, IsWrapped, Hook),

--- a/src/avro_json_decoder.erl
+++ b/src/avro_json_decoder.erl
@@ -513,8 +513,10 @@ parse_union(_, _, _, _, _) ->
 %% @private
 parse_union_ex(ValueTypeName, Value, UnionType, ExtractFun, IsWrapped, Hook) ->
   Hook(UnionType, ValueTypeName, Value,
-       fun(In) -> do_parse_union_ex(ValueTypeName, In, UnionType,
-                                    ExtractFun, IsWrapped, Hook) end).
+       fun(In) ->
+          do_parse_union_ex(ValueTypeName, In, UnionType,
+                            ExtractFun, IsWrapped, Hook)
+       end).
 
 %% @private
 do_parse_union_ex(ValueTypeName, Value, UnionType,

--- a/src/avro_json_encoder.erl
+++ b/src/avro_json_encoder.erl
@@ -85,8 +85,8 @@ encode(Lkup, TypeOrName, Value) ->
 %%%===================================================================
 
 %% @private
-do_encode(_Lkup, _, Value) when ?IS_AVRO_VALUE(Value) ->
-  encode_value(Value, mochijson3);
+do_encode(_Lkup, Type, #avro_value{type = Type} = V) ->
+  do_encode_value(V);
 do_encode(Lkup, TypeName, Value) when ?IS_NAME(TypeName) ->
   do_encode(Lkup, Lkup(TypeName), Value);
 do_encode(_Lkup, Type, Value) when ?AVRO_IS_PRIMITIVE_TYPE(Type) ->
@@ -111,7 +111,7 @@ do_encode(_Lkup, Type, null) when ?AVRO_IS_UNION_TYPE(Type) ->
   null; %do not encode null
 do_encode(Lkup, Type, Union) when ?AVRO_IS_UNION_TYPE(Type) ->
   Encoded = avro_union:encode(Type, Union,
-    fun(MemberT, Value, _) ->
+    fun(MemberT, Value, _UnionIndex) ->
       {
         encode_string(avro:get_type_fullname(MemberT)),
         do_encode(Lkup, MemberT, Value)

--- a/src/avro_json_encoder.erl
+++ b/src/avro_json_encoder.erl
@@ -85,6 +85,8 @@ encode(Lkup, TypeOrName, Value) ->
 %%%===================================================================
 
 %% @private
+do_encode(_Lkup, _, Value) when ?IS_AVRO_VALUE(Value) ->
+  encode_value(Value, mochijson3);
 do_encode(Lkup, TypeName, Value) when ?IS_NAME(TypeName) ->
   do_encode(Lkup, Lkup(TypeName), Value);
 do_encode(_Lkup, Type, Value) when ?AVRO_IS_PRIMITIVE_TYPE(Type) ->

--- a/src/avro_primitive.erl
+++ b/src/avro_primitive.erl
@@ -127,7 +127,7 @@ cast(Type, Value) when ?AVRO_IS_BYTES_TYPE(Type) andalso
   {ok, ?AVRO_VALUE(Type, Value)};
 
 cast(Type, Value) when ?AVRO_IS_STRING_TYPE(Type) andalso
-                       is_list(Value) ->
+                       (is_list(Value) orelse is_binary(Value)) ->
   {ok, ?AVRO_VALUE(Type, Value)};
 
 %% Casts from other primitive Avro types so that we don't lose data

--- a/src/erlavro.app.src
+++ b/src/erlavro.app.src
@@ -1,7 +1,7 @@
 {application, erlavro,
  [
   {description, "Apache Avro support for Erlang"},
-  {vsn, "1.9.0"},
+  {vsn, "1.9.1"},
   {registered, []},
   {applications, [
                   kernel,

--- a/test/avro_binary_decoder_tests.erl
+++ b/test/avro_binary_decoder_tests.erl
@@ -190,7 +190,7 @@ decode_with_hook_test() ->
   Binary = sample_record_binary(),
   Schema = sample_record_type(),
   Lkup = fun(_) -> exit(error) end,
-  Hook = avro_util:pretty_print_decoder_hook(),
+  Hook = avro_decoder_hooks:pretty_print_hist(),
   Fields = decode(Binary, Schema, Lkup, Hook),
   ?assertMatch([ {"bool",   true}
     , {"int",    100}

--- a/test/avro_binary_encoder_tests.erl
+++ b/test/avro_binary_encoder_tests.erl
@@ -152,7 +152,7 @@ encode_map_test() ->
   TypedValue = avro_map:new(Type, [{"a", 3}, {"b", 27}]),
   Body = iolist_to_binary([string("a"),
     int(3),
-    string("b"),
+    string(<<"b">>),
     int(27)]),
   ?assertBinEq([long(-2),
     long(size(Body)),

--- a/test/avro_decoder_hooks_tests.erl
+++ b/test/avro_decoder_hooks_tests.erl
@@ -1,0 +1,52 @@
+%%%-------------------------------------------------------------------
+%%% Copyright (c) 2013-2016 Klarna AB
+%%%
+%%% This file is provided to you under the Apache License,
+%%% Version 2.0 (the "License"); you may not use this file
+%%% except in compliance with the License.  You may obtain
+%%% a copy of the License at
+%%%
+%%%   http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing,
+%%% software distributed under the License is distributed on an
+%%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%%% KIND, either express or implied.  See the License for the
+%%% specific language governing permissions and limitations
+%%% under the License.
+%%%
+%%%-------------------------------------------------------------------
+-module(avro_decoder_hooks_tests).
+
+-include("avro_internal.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+debug_hook_test() ->
+  LogFun = fun(IoData) -> io:put_chars(user, IoData) end,
+  HistLen = 10,
+  Hook = avro_decoder_hooks:binary_decoder_debug_trace(LogFun, HistLen),
+  MyRecordType =
+    avro_record:type(
+      "MyRecord",
+      [avro_record:define_field("f1", avro_primitive:int_type()),
+       avro_record:define_field("f2", avro_primitive:string_type())],
+      [{namespace, "my.com"}]),
+  Store = avro_schema_store:add_type(MyRecordType, avro_schema_store:new([])),
+  Encoder = avro:get_encoder(Store, []),
+  Term = [{"f1", 1},{"f2","my string"}],
+  Bin = iolist_to_binary(Encoder("my.com.MyRecord", Term)),
+  %% Mkae a corrupted binary to decode
+  BadSize = size(Bin) - 1,
+  CorruptedBin = <<Bin:BadSize/binary>>,
+  Decoder = avro:get_decoder(Store, [{hook, Hook}]),
+  ?assertException(
+    _Class,
+    {'$hook-raised', _},
+    Decoder(CorruptedBin, "my.com.MyRecord")),
+  ok.
+
+%%%_* Emacs ====================================================================
+%%% Local Variables:
+%%% allout-layout: t
+%%% erlang-indent-level: 2
+%%% End:

--- a/test/avro_decoder_hooks_tests.erl
+++ b/test/avro_decoder_hooks_tests.erl
@@ -34,7 +34,7 @@ debug_hook_test() ->
   Store = avro_schema_store:add_type(MyRecordType, avro_schema_store:new([])),
   Encoder = avro:get_encoder(Store, []),
   Term = [{"f1", 1},{"f2","my string"}],
-  Bin = iolist_to_binary(Encoder("my.com.MyRecord", Term)),
+  Bin = iolist_to_binary(Encoder(Term, "my.com.MyRecord")),
   %% Mkae a corrupted binary to decode
   BadSize = size(Bin) - 1,
   CorruptedBin = <<Bin:BadSize/binary>>,

--- a/test/avro_decoder_hooks_tests.erl
+++ b/test/avro_decoder_hooks_tests.erl
@@ -36,18 +36,18 @@ test_debug_hook(Encoding) ->
       "MyRecord",
       [avro_record:define_field("f1", avro_primitive:int_type()),
        avro_record:define_field("f2", avro_primitive:string_type())],
-      [{namespace, "my.com"}]),
+      [{namespace, "com.example"}]),
   Store = avro_schema_store:add_type(MyRecordType, avro_schema_store:new([])),
-  Encoder = avro:get_encoder(Store, CodecOptions),
+  Encoder = avro:make_encoder(Store, CodecOptions),
   Term = [{"f1", 1},{"f2","my-string"}],
-  Bin = iolist_to_binary(Encoder(Term, "my.com.MyRecord")),
+  Bin = iolist_to_binary(Encoder("com.example.MyRecord", Term)),
   %% Mkae a corrupted binary to decode
   CorruptedBin = corrupt_encoded(Encoding, Bin),
-  Decoder = avro:get_decoder(Store, [{hook, Hook} | CodecOptions]),
+  Decoder = avro:make_decoder(Store, [{hook, Hook} | CodecOptions]),
   ?assertException(
     _Class,
     {'$hook-raised', _},
-    Decoder(CorruptedBin, "my.com.MyRecord")),
+    Decoder("com.example.MyRecord", CorruptedBin)),
   ok.
 
 %% @private

--- a/test/avro_json_decoder_tests.erl
+++ b/test/avro_json_decoder_tests.erl
@@ -252,10 +252,8 @@ parse_fixed_value_test() ->
   ?assertEqual(Expected, parse_value(Json, Type, none)).
 
 parse_value_with_extract_type_fun_test() ->
-  Hook = avro_util:pretty_print_decoder_hook(),
-  ExtractTypeFun = fun("name.space.Test") ->
-    get_test_record()
-                   end,
+  Hook = avro_decoder_hooks:pretty_print_hist(),
+  ExtractTypeFun = fun("name.space.Test") -> get_test_record() end,
   Schema = {struct, [ {<<"type">>, <<"array">>}
     , {<<"items">>, <<"Test">>}
   ]},
@@ -272,7 +270,6 @@ parse_value_with_extract_type_fun_test() ->
   ?assertEqual("name.space.Test",
     avro:get_type_fullname(?AVRO_VALUE_TYPE(Rec))),
   ?assertEqual(avro_primitive:long(100), avro_record:get_value("invno", Rec)).
-
 
 %% @private
 get_test_record() ->

--- a/test/avro_record_tests.erl
+++ b/test/avro_record_tests.erl
@@ -147,7 +147,7 @@ cast_by_aliases_test() ->
 new_encoded_test() ->
   Type = avro_record:type("Test",
     [ avro_record:define_field("field1", avro_primitive:long_type())
-      , avro_record:define_field("field2", avro_primitive:string_type())
+    , avro_record:define_field("field2", avro_primitive:string_type())
     ],
     [ {namespace, "name.space"}
     ]),

--- a/test/erlavro_readme_tests.erl
+++ b/test/erlavro_readme_tests.erl
@@ -25,11 +25,11 @@ load_schmea_test() ->
   SchemaFilename = filename:join(priv_dir(), "interop.avsc"),
   OcfFilename = filename:join(priv_dir(), "interop.ocf"),
   Store = avro_schema_store:new([], [SchemaFilename]),
-  Encoder = avro:get_encoder(Store, []),
-  Decoder = avro:get_decoder(Store, []),
+  Encoder = avro:make_encoder(Store, []),
+  Decoder = avro:make_decoder(Store, []),
   Term = hd(element(3, avro_ocf:decode_file(OcfFilename))),
-  Encoded = iolist_to_binary(Encoder(Term, "org.apache.avro.Interop")),
-  Term = Decoder(Encoded, "org.apache.avro.Interop"),
+  Encoded = iolist_to_binary(Encoder("org.apache.avro.Interop", Term)),
+  Term = Decoder("org.apache.avro.Interop", Encoded),
   ok.
 
 binary_encode_decode_test() ->
@@ -38,13 +38,13 @@ binary_encode_decode_test() ->
       "MyRecord",
       [avro_record:define_field("f1", avro_primitive:int_type()),
        avro_record:define_field("f2", avro_primitive:string_type())],
-      [{namespace, "my.com"}]),
+      [{namespace, "com.example"}]),
   Store = avro_schema_store:add_type(MyRecordType, avro_schema_store:new([])),
-  Encoder = avro:get_encoder(Store, []),
-  Decoder = avro:get_decoder(Store, []),
+  Encoder = avro:make_encoder(Store, []),
+  Decoder = avro:make_decoder(Store, []),
   Term = [{"f1", 1},{"f2","my string"}],
-  Bin = Encoder(Term, "my.com.MyRecord"),
-  Term = Decoder(Bin, "my.com.MyRecord"),
+  Bin = Encoder("com.example.MyRecord", Term),
+  Term = Decoder("com.example.MyRecord", Bin),
   ok.
 
 json_encode_decode_test() ->
@@ -53,13 +53,13 @@ json_encode_decode_test() ->
       "MyRecord",
       [avro_record:define_field("f1", avro_primitive:int_type()),
        avro_record:define_field("f2", avro_primitive:string_type())],
-      [{namespace, "my.com"}]),
+      [{namespace, "com.example"}]),
   Store = avro_schema_store:add_type(MyRecordType, avro_schema_store:new([])),
-  Encoder = avro:get_encoder(Store, [{encoding, avro_json}]),
-  Decoder = avro:get_decoder(Store, [{encoding, avro_json}]),
+  Encoder = avro:make_encoder(Store, [{encoding, avro_json}]),
+  Decoder = avro:make_decoder(Store, [{encoding, avro_json}]),
   Term = [{"f1", 1},{"f2", "my string"}],
-  JSON = Encoder(Term, "my.com.MyRecord"),
-  Term = Decoder(JSON, "my.com.MyRecord"),
+  JSON = Encoder("com.example.MyRecord", Term),
+  Term = Decoder("com.example.MyRecord", JSON),
   io:put_chars(user, JSON),
   ok.
 
@@ -76,13 +76,13 @@ encode_wrapped(CodecOptions) ->
       "MyRecord1",
       [avro_record:define_field("f1", NullableInt),
        avro_record:define_field("f2", avro_primitive:string_type())],
-      [{namespace, "my.com"}]),
+      [{namespace, "com.example"}]),
   MyRecordType2 =
     avro_record:type(
       "MyRecord2",
       [avro_record:define_field("f1", avro_primitive:string_type()),
        avro_record:define_field("f2", NullableInt)],
-      [{namespace, "my.com"}]),
+      [{namespace, "com.example"}]),
   MyUnion = avro_union:type([MyRecordType1, MyRecordType2]),
   MyArray = avro_array:type(MyUnion),
   Lkup = fun(_) -> erlang:error("not expecting type lookup because "
@@ -90,25 +90,25 @@ encode_wrapped(CodecOptions) ->
                                 "i.e. no name references") end,
   %% Encode Records with type info wrapped
   %% so they can be used as a drop-in part of wrapper object
-  WrappedEncoder = avro:get_encoder(Lkup, [wrapped | CodecOptions]),
+  WrappedEncoder = avro:make_encoder(Lkup, [wrapped | CodecOptions]),
   T1 = [{"f1", null}, {"f2", "str1"}],
   T2 = [{"f1", "str2"}, {"f2", 2}],
   %% Encode the records with type info wrapped
-  R1 = WrappedEncoder(T1, MyRecordType1),
-  R2 = WrappedEncoder(T2, MyRecordType2),
+  R1 = WrappedEncoder(MyRecordType1, T1),
+  R2 = WrappedEncoder(MyRecordType2, T2),
   %% Tag the union values for better encoding performance
-  U1 = {"my.com.MyRecord1", R1},
-  U2 = {"my.com.MyRecord2", R2},
+  U1 = {"com.example.MyRecord1", R1},
+  U2 = {"com.example.MyRecord2", R2},
   %% This encoder returns iodata result without type info wrapped
-  BinaryEncoder = avro:get_encoder(Lkup, CodecOptions),
+  BinaryEncoder = avro:make_encoder(Lkup, CodecOptions),
   %% Construct the array from encoded elements
-  Bin = iolist_to_binary(BinaryEncoder([U1, U2], MyArray)),
+  Bin = iolist_to_binary(BinaryEncoder(MyArray, [U1, U2])),
   %% Tag the decoded values
   Hook = avro_decoder_hooks:tag_unions(),
-  Decoder = avro:get_decoder(Lkup, [{hook, Hook} | CodecOptions]),
-  [ {"my.com.MyRecord1", [{"f1", null}, {"f2", "str1"}]}
-  , {"my.com.MyRecord2", [{"f1", "str2"}, {"f2", 2}]}
-  ] = Decoder(Bin, MyArray),
+  Decoder = avro:make_decoder(Lkup, [{hook, Hook} | CodecOptions]),
+  [ {"com.example.MyRecord1", [{"f1", null}, {"f2", "str1"}]}
+  , {"com.example.MyRecord2", [{"f1", "str2"}, {"f2", 2}]}
+  ] = Decoder(MyArray, Bin),
   ok.
 
 %% @private

--- a/test/erlavro_readme_tests.erl
+++ b/test/erlavro_readme_tests.erl
@@ -42,7 +42,7 @@ binary_encode_decode_test() ->
   Store = avro_schema_store:add_type(MyRecordType, avro_schema_store:new([])),
   Encoder = avro:make_encoder(Store, []),
   Decoder = avro:make_decoder(Store, []),
-  Term = [{"f1", 1},{"f2","my string"}],
+  Term = [{"f1", 1}, {"f2", "my string"}],
   Bin = Encoder("com.example.MyRecord", Term),
   Term = Decoder("com.example.MyRecord", Bin),
   ok.
@@ -57,7 +57,7 @@ json_encode_decode_test() ->
   Store = avro_schema_store:add_type(MyRecordType, avro_schema_store:new([])),
   Encoder = avro:make_encoder(Store, [{encoding, avro_json}]),
   Decoder = avro:make_decoder(Store, [{encoding, avro_json}]),
-  Term = [{"f1", 1},{"f2", "my string"}],
+  Term = [{"f1", 1}, {"f2", "my string"}],
   JSON = Encoder("com.example.MyRecord", Term),
   Term = Decoder("com.example.MyRecord", JSON),
   io:put_chars(user, JSON),

--- a/test/erlavro_readme_tests.erl
+++ b/test/erlavro_readme_tests.erl
@@ -107,7 +107,7 @@ encode_wrapped(CodecOptions) ->
   Hook = avro_decoder_hooks:tag_unions(),
   Decoder = avro:get_decoder(Lkup, [{hook, Hook} | CodecOptions]),
   [ {"my.com.MyRecord1", [{"f1", null}, {"f2", "str1"}]}
-  , {"my.com.MyRecord2", [{"f1", "str2"}, {"f2", {"int", 2}}]}
+  , {"my.com.MyRecord2", [{"f1", "str2"}, {"f2", 2}]}
   ] = Decoder(Bin, MyArray),
   ok.
 

--- a/test/erlavro_readme_tests.erl
+++ b/test/erlavro_readme_tests.erl
@@ -104,7 +104,7 @@ encode_wrapped(CodecOptions) ->
   %% Construct the array from encoded elements
   Bin = iolist_to_binary(BinaryEncoder([U1, U2], MyArray)),
   %% Tag the decoded values
-  Hook = avro_decoder_hooks:tag_unions_fun(),
+  Hook = avro_decoder_hooks:tag_unions(),
   Decoder = avro:get_decoder(Lkup, [{hook, Hook} | CodecOptions]),
   [ {"my.com.MyRecord1", [{"f1", null}, {"f2", "str1"}]}
   , {"my.com.MyRecord2", [{"f1", "str2"}, {"f2", {"int", 2}}]}


### PR DESCRIPTION
* Allow tagging union values for `encode/3` APIs -- For better union encoding performance
* Support wrapped values as 'already encoded' parts of complex parent wrappers to allow `encod/3` from bottom up
* Added `get_encoder` and `get_decoder` APIs to hide `avro_json|binary_encode|decoder`
* Added more decoder hooks