### PR TITLE
Use type full name in encoded wrapped value.

### DIFF
--- a/include/erlavro.hrl
+++ b/include/erlavro.hrl
@@ -20,7 +20,7 @@
 -define(_ERLAVRO_HRL_, true).
 
 -record(avro_value,
-        { type :: avro:avro_type()
+        { type :: avro:avro_type_or_name()
         , data :: avro:avro_value()
         }).
 
@@ -29,8 +29,8 @@
                     | [#avro_value{}]                %% array
                     | [{avro:name(), #avro_value{}}] %% record
                     | avro_map:data()                %% map
-                    | {json, iodata()}               %% serialized
-                    | {binary, iodata()}.            %% serialized
+                    | {json, binary()}               %% serialized
+                    | {binary, binary()}.            %% serialized
 
 -define(IS_AVRO_VALUE(Value), is_record(Value, avro_value)).
 -define(AVRO_VALUE(Type,Data), #avro_value{type = Type, data = Data}).

--- a/src/avro_union.erl
+++ b/src/avro_union.erl
@@ -223,7 +223,7 @@ try_encode_union_loop(UnionType, [], Value, _Index, _EncodeFun) ->
 try_encode_union_loop(UnionType, [MemberT | Rest], Value, Index, EncodeFun) ->
   try
     EncodeFun(MemberT, Value, Index)
-  catch _ : _ ->
+  catch _C : _E ->
     try_encode_union_loop(UnionType, Rest, Value, Index + 1, EncodeFun)
   end.
 

--- a/test/avro_record_tests.erl
+++ b/test/avro_record_tests.erl
@@ -151,24 +151,6 @@ cast_by_aliases_test() ->
   ?assertEqual(avro_primitive:string("foo"), get_value("a", Record)),
   ?assertEqual(avro_primitive:int(1), get_value("b", Record)).
 
-new_encoded_test() ->
-  Type = type("Test",
-              [ define_field("field1", long)
-              , define_field("field2", string)],
-              [ {namespace, "name.space"} ]),
-  Fields = [ {"field1", avro_primitive:long(1)}
-           , {"field2", avro_primitive:string("f")}
-           ],
-  Lkup = fun(_) -> erlang:error(unexpected) end,
-  Rec = avro:encode_wrapped(Lkup, Type, Fields, avro_json),
-  ?assertException(throw, {value_already_encoded, _},
-                   get_value("any", Rec)),
-  ?assertException(throw, {value_already_encoded, _},
-                   set_value("any", "whatever", Rec)),
-  ?assertException(throw, {value_already_encoded, _},
-                   update("any", fun()-> "care not" end, Rec)),
-  ?assertException(throw, {value_already_encoded, _}, to_list(Rec)).
-
 encode_test() ->
   EncodeFun = fun({FieldName, _FieldType, Input}) ->
                   {FieldName, {encoded, Input}}


### PR DESCRIPTION
The wrapped-encoded value is `#avro_value{type :: avro_type(), value :: binary()}`
this is useful when encoding part of a lower level pieces of large objects and assemble them
back for the wrapping object later on.

the `type` part is sometimes too complex when it is a complex type, 
for example, a record of many fields or a big union.
This PR is to use the type name instead of the type definition for named types to save memory.
And for more efficient pattern match.