### PR TITLE
Add avro_ocf:decode_binary/1.

### DIFF
--- a/src/avro_ocf.erl
+++ b/src/avro_ocf.erl
@@ -24,6 +24,7 @@
 -module(avro_ocf).
 
 -export([ append_file/5
+        , decode_binary/1
         , decode_file/1
         , make_header/1
         , write_header/2
@@ -54,6 +55,11 @@
 -spec decode_file(filename()) -> {header(), avro_type(), [avro:out()]}.
 decode_file(Filename) ->
   {ok, Bin} = file:read_file(Filename),
+  decode_binary(Bin).
+
+%% @doc Decode ocf binary into unwrapped values.
+-spec decode_binary(binary()) -> {header(), avro_type(), [avro:out()]}.
+decode_binary(Bin) ->
   {[ {<<"magic">>, Magic}
    , {<<"meta">>, Meta}
    , {<<"sync">>, Sync}

--- a/src/erlavro.app.src
+++ b/src/erlavro.app.src
@@ -1,7 +1,7 @@
 {application, erlavro,
   [
     {description, "Apache Avro support for Erlang/Elixir"},
-    {vsn, "2.0.1"},
+    {vsn, "2.0.2"},
     {registered, []},
     {applications, [
       kernel,


### PR DESCRIPTION
For decoding ocf formatted data when you already have the binary in memory.

I am parsing ocf formatted data directly from an AWS Kinesis stream, so this would be really helpful. I didn't add any new tests because it seemed like the existing decode_file/1 tests cover it, but let me know if you would like to see an explicit test.

Thanks for your work on this lib!