### PR TITLE
Export OCF functions

### DIFF
--- a/src/avro_ocf.erl
+++ b/src/avro_ocf.erl
@@ -25,10 +25,13 @@
 
 -export([ append_file/5
         , decode_binary/1
+        , decode_blocks/5
         , decode_file/1
+        , decode_stream/2
         , make_header/1
         , write_header/2
         , write_file/4
+        , ocf_schema/0
         ]).
 
 -export_type([ header/0


### PR DESCRIPTION
We'd like to export these three functions so we can use them from our `avrolixr` library (https://github.com/avvo/avrolixr).

See: https://github.com/avvo/avrolixr/blob/master/lib/avrolixr/codec.ex, especially lines 111-119