### PR TITLE
Keep default values raw (no parsing)

### DIFF
--- a/src/avro.erl
+++ b/src/avro.erl
@@ -23,7 +23,8 @@
 
 -module(avro).
 
--export([ expand_type/2
+-export([ decode_schema/1
+        , expand_type/2
         , expand_type_bloated/2
         , flatten_type/1
         , get_aliases/1
@@ -114,6 +115,9 @@
 -type encode_fun() :: fun((type_or_name(), term()) -> iodata() | avro_value()).
 -type decode_fun() :: fun((type_or_name(), binary()) -> term()).
 -type encoding() :: avro_encoding().
+
+%% @doc Decode JSON format avro schema into erlavro internals.
+decode_schema(JSON) -> avro_json_decoder:decode_schema(JSON).
 
 %% @doc Make a encoder function.
 %% Supported codec options:


### PR DESCRIPTION
We do not care what default value is provided in JSON schema.
Valid or invalid, matters not.

Two cases for future useage:
1. Use default value to encode missing fields in `avro:in()`
   when encoding avro JSON or binary stream.
2. Use default value to up-vert or down-vert decoded `avro:out()`

For case 1, the encoder will crash if invalid value is found
in schema, user will have to fix schema anyway.

For case 2, invalid value will be exposed to higher level, then
it's up to the caller to decide either fix code or schema.