### PR TITLE
Parsing canonical form

### DIFF
--- a/src/avro.erl
+++ b/src/avro.erl
@@ -26,6 +26,7 @@
 -export([ decode_schema/1
         , decode_schema/2
         , encode_schema/1
+        , encode_schema/2
         , expand_type/2
         , expand_type_bloated/2
         , flatten_type/1
@@ -177,6 +178,10 @@ decode_schema(JSON, Options) ->
 -spec encode_schema(avro_type()) -> binary().
 encode_schema(Type) ->
   avro_json_encoder:encode_schema(Type).
+
+-spec encode_schema(avro_type(), schema_opts()) -> binary().
+encode_schema(Type, Options) ->
+  avro_json_encoder:encode_schema(Type, Options).
 
 %% @doc Make a encoder function.
 %% Supported codec options:

--- a/src/avro_json_encoder.erl
+++ b/src/avro_json_encoder.erl
@@ -131,8 +131,8 @@ enc(Lkup, Type, Union) when ?IS_UNION_TYPE(Type) ->
   [Encoded].
 
 %% @private
-optional_field(_Key, Default, Default, _MappingFun, _Opt) -> [];
-optional_field(Key, Value, _Default, MappingFun, _Opt) ->
+optional_field(_Key, Default, Default, _MappingFun) -> [];
+optional_field(Key, Value, _Default, MappingFun) ->
     [{Key, MappingFun(Value)}].
 
 % type, name, fields, symbols, items, values, size
@@ -179,11 +179,11 @@ do_encode_type(#avro_record_type{} = T, EnclosingNamespace, Opt) ->
   {Name, NextLevelEnclosingNs} = avro:split_type_name(T, Namespace),
   SchemaObjectFields =
     [ optional_field(namespace, ns(Namespace, EnclosingNamespace),
-                     ?NS_GLOBAL, fun encode_string/1, Opt)
+                     ?NS_GLOBAL, fun encode_string/1)
     , {name, encode_string(Name)}
     , {type, encode_string(?AVRO_RECORD)}
-    , optional_field(doc,       Doc,  ?NO_DOC, fun encode_string/1, Opt)
-    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1, Opt)
+    , optional_field(doc,       Doc,  ?NO_DOC, fun encode_string/1)
+    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1)
     , {fields, lists:map(fun(F) ->
                              encode_field(F, NextLevelEnclosingNs, Opt)
                          end, Fields)}
@@ -200,7 +200,7 @@ do_encode_type(#avro_enum_type{} = T, _Ns, #{canon := true}) ->
     , {symbols, lists:map(fun encode_string/1, Symbols)}
     ],
   lists:flatten(SchemaObjectFields);
-do_encode_type(#avro_enum_type{} = T, EnclosingNamespace, Opt) ->
+do_encode_type(#avro_enum_type{} = T, EnclosingNamespace, _Opt) ->
   #avro_enum_type{ name      = Name
                  , namespace = Namespace
                  , aliases   = Aliases
@@ -210,11 +210,11 @@ do_encode_type(#avro_enum_type{} = T, EnclosingNamespace, Opt) ->
                  } = T,
   SchemaObjectFields =
     [ optional_field(namespace, ns(Namespace, EnclosingNamespace),
-                     ?NS_GLOBAL, fun encode_string/1, Opt)
+                     ?NS_GLOBAL, fun encode_string/1)
     , {name, encode_string(Name)}
     , {type, encode_string(?AVRO_ENUM)}
-    , optional_field(doc,       Doc,  ?NO_DOC, fun encode_string/1, Opt)
-    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1, Opt)
+    , optional_field(doc,       Doc,  ?NO_DOC, fun encode_string/1)
+    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1)
     , {symbols, lists:map(fun encode_string/1, Symbols)}
     | CustomProps
     ],
@@ -260,7 +260,7 @@ do_encode_type(#avro_fixed_type{} = T, _Ns, #{canon := true}) ->
     , {size, encode_integer(Size)}
     ],
   lists:flatten(SchemaObjectFields);
-do_encode_type(#avro_fixed_type{} = T, EnclosingNamespace, Opt) ->
+do_encode_type(#avro_fixed_type{} = T, EnclosingNamespace, _Opt) ->
   #avro_fixed_type{ name      = Name
                   , namespace = Namespace
                   , aliases   = Aliases
@@ -269,11 +269,11 @@ do_encode_type(#avro_fixed_type{} = T, EnclosingNamespace, Opt) ->
                   } = T,
   SchemaObjectFields =
     [ optional_field(namespace, ns(Namespace, EnclosingNamespace),
-                     ?NS_GLOBAL, fun encode_string/1, Opt)
+                     ?NS_GLOBAL, fun encode_string/1)
     , {name, encode_string(Name)}
     , {type, encode_string(?AVRO_FIXED)}
     , {size, encode_integer(Size)}
-    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1, Opt)
+    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1)
     | CustomProps
     ],
   lists:flatten(SchemaObjectFields).
@@ -295,10 +295,10 @@ encode_field(Field, EnclosingNamespace, Opt) ->
   [ {name, encode_string(Name)}
   , {type, do_encode_type(Type, EnclosingNamespace, Opt)}
   ]
-  ++ optional_field(default, Default, ?NO_VALUE, fun(X) -> ?INLINE(X) end, Opt)
-  ++ optional_field(doc,     Doc,     ?NO_DOC,   fun encode_string/1, Opt)
-  ++ optional_field(order,   Order,   ascending, fun encode_order/1, Opt)
-  ++ optional_field(aliases, Aliases, [],        fun encode_aliases/1, Opt).
+  ++ optional_field(default, Default, ?NO_VALUE, fun(X) -> ?INLINE(X) end)
+  ++ optional_field(doc,     Doc,     ?NO_DOC,   fun encode_string/1)
+  ++ optional_field(order,   Order,   ascending, fun encode_order/1)
+  ++ optional_field(aliases, Aliases, [],        fun encode_aliases/1).
 
 %% @private Get namespace to encode.
 %% Ignore namespace to encode if it is the same as enclosing namesapce

--- a/src/avro_json_encoder.erl
+++ b/src/avro_json_encoder.erl
@@ -132,10 +132,7 @@ enc(Lkup, Type, Union) when ?IS_UNION_TYPE(Type) ->
 
 %% @private
 optional_field(_Key, Default, Default, _MappingFun) -> [];
-optional_field(Key, Value, _Default, MappingFun) ->
-    [{Key, MappingFun(Value)}].
-
-% type, name, fields, symbols, items, values, size
+optional_field(Key, Value, _Default, MappingFun) -> [{Key, MappingFun(Value)}].
 
 %% @private
 do_encode_type(Name, _Ns, #{canon := true}) when ?IS_NAME(Name) ->

--- a/src/avro_json_encoder.erl
+++ b/src/avro_json_encoder.erl
@@ -29,6 +29,7 @@
 
 %% API
 -export([ encode_schema/1
+        , encode_schema/2
         , encode_type/1
         , encode_value/1
         , encode/3
@@ -44,11 +45,18 @@
 %% @doc Encode avro schema in JSON format.
 %% @end
 -spec encode_schema(avro_type()) -> iodata().
-encode_schema(Type0) ->
+encode_schema(Type) ->
+    encode_schema(Type, []).
+
+-spec encode_schema(avro_type(), avro:schema_opts()) -> iodata().
+encode_schema(Type0, Opt) ->
   Type1 = avro_util:resolve_duplicated_refs(Type0),
   Lkup = avro:make_lkup_fun(?ASSIGNED_NAME, Type1),
   Type = avro_util:encode_defaults(Type1, Lkup),
-  encode_json(do_encode_type(Type, _Namespace = ?NS_GLOBAL)).
+  OptMap = lists:foldl(fun ({Key, Value}, Acc) ->
+                               maps:put(Key, Value, Acc)
+                       end, #{}, Opt),
+  encode_json(do_encode_type(Type, _Namespace = ?NS_GLOBAL, OptMap)).
 
 %% @doc Encode avro schema in JSON format.
 -spec encode_type(avro_type()) -> iodata().
@@ -123,24 +131,44 @@ enc(Lkup, Type, Union) when ?IS_UNION_TYPE(Type) ->
   [Encoded].
 
 %% @private
-optional_field(_Key, Default, Default, _MappingFun) -> [];
-optional_field(Key, Value, _Default, MappingFun) -> [{Key, MappingFun(Value)}].
+optional_field(_Key, Default, Default, _MappingFun, _Opt) -> [];
+optional_field(Key, Value, _Default, MappingFun, _Opt) ->
+    [{Key, MappingFun(Value)}].
+
+% type, name, fields, symbols, items, values, size
 
 %% @private
-do_encode_type(Name, EnclosingNamespace) when ?IS_NAME(Name) ->
+do_encode_type(Name, _Ns, #{canon := true}) when ?IS_NAME(Name) ->
+  encode_string(Name);
+do_encode_type(Name, EnclosingNamespace, _Opt) when ?IS_NAME(Name) ->
   MaybeShortName =
     case avro:split_type_name(Name, EnclosingNamespace) of
       {ShortName, EnclosingNamespace} -> ShortName;
       {_ShortName, _AnotherNamespace} -> Name
     end,
   encode_string(MaybeShortName);
-do_encode_type(#avro_primitive_type{name = Name, custom = []}, _Ns) ->
+do_encode_type(#avro_primitive_type{name = Name, custom = []}, _Ns, _Opt) ->
   encode_string(Name);
-do_encode_type(#avro_primitive_type{name = Name, custom = Custom}, _Ns) ->
+do_encode_type(#avro_primitive_type{name = Name, custom = Custom}, _Ns, _Opt) ->
   [ {type, encode_string(Name)}
   | Custom
   ];
-do_encode_type(#avro_record_type{} = T, EnclosingNamespace) ->
+do_encode_type(#avro_record_type{} = T, _Ns, #{canon := true} = Opt) ->
+  #avro_record_type{ name      = Name
+                   , fullname  = Fullname
+                   , namespace = Namespace
+                   , fields    = Fields
+                   } = T,
+  {Name, NextLevelEnclosingNs} = avro:split_type_name(T, Namespace),
+  SchemaObjectFields =
+    [ {name, encode_string(Fullname)}
+    , {type, encode_string(?AVRO_RECORD)}
+    , {fields, lists:map(fun(F) ->
+                             encode_field(F, NextLevelEnclosingNs, Opt)
+                         end, Fields)}
+    ],
+  lists:flatten(SchemaObjectFields);
+do_encode_type(#avro_record_type{} = T, EnclosingNamespace, Opt) ->
   #avro_record_type{ name      = Name
                    , namespace = Namespace
                    , doc       = Doc
@@ -151,18 +179,28 @@ do_encode_type(#avro_record_type{} = T, EnclosingNamespace) ->
   {Name, NextLevelEnclosingNs} = avro:split_type_name(T, Namespace),
   SchemaObjectFields =
     [ optional_field(namespace, ns(Namespace, EnclosingNamespace),
-                     ?NS_GLOBAL, fun encode_string/1)
-    , {type,   encode_string(?AVRO_RECORD)}
-    , {name,   encode_string(Name)}
-    , optional_field(doc,       Doc,  ?NO_DOC, fun encode_string/1)
-    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1)
+                     ?NS_GLOBAL, fun encode_string/1, Opt)
+    , {name, encode_string(Name)}
+    , {type, encode_string(?AVRO_RECORD)}
+    , optional_field(doc,       Doc,  ?NO_DOC, fun encode_string/1, Opt)
+    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1, Opt)
     , {fields, lists:map(fun(F) ->
-                             encode_field(F, NextLevelEnclosingNs)
+                             encode_field(F, NextLevelEnclosingNs, Opt)
                          end, Fields)}
     | CustomProps
     ],
   lists:flatten(SchemaObjectFields);
-do_encode_type(#avro_enum_type{} = T, EnclosingNamespace) ->
+do_encode_type(#avro_enum_type{} = T, _Ns, #{canon := true}) ->
+  #avro_enum_type{ fullname  = Fullname
+                 , symbols   = Symbols
+                 } = T,
+  SchemaObjectFields =
+    [ {name, encode_string(Fullname)}
+    , {type, encode_string(?AVRO_ENUM)}
+    , {symbols, lists:map(fun encode_string/1, Symbols)}
+    ],
+  lists:flatten(SchemaObjectFields);
+do_encode_type(#avro_enum_type{} = T, EnclosingNamespace, Opt) ->
   #avro_enum_type{ name      = Name
                  , namespace = Namespace
                  , aliases   = Aliases
@@ -172,34 +210,57 @@ do_encode_type(#avro_enum_type{} = T, EnclosingNamespace) ->
                  } = T,
   SchemaObjectFields =
     [ optional_field(namespace, ns(Namespace, EnclosingNamespace),
-                     ?NS_GLOBAL, fun encode_string/1)
-    , {type,    encode_string(?AVRO_ENUM)}
-    , {name,    encode_string(Name)}
-    , optional_field(doc,       Doc,  ?NO_DOC, fun encode_string/1)
-    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1)
+                     ?NS_GLOBAL, fun encode_string/1, Opt)
+    , {name, encode_string(Name)}
+    , {type, encode_string(?AVRO_ENUM)}
+    , optional_field(doc,       Doc,  ?NO_DOC, fun encode_string/1, Opt)
+    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1, Opt)
     , {symbols, lists:map(fun encode_string/1, Symbols)}
     | CustomProps
     ],
   lists:flatten(SchemaObjectFields);
 do_encode_type(#avro_array_type{ type   = Type
-                               , custom = CustomProps
-                               }, EnclosingNamespace) ->
+                               }, EnclosingNamespace, #{canon := true} = Opt) ->
   [ {type,  encode_string(?AVRO_ARRAY)}
-  , {items, do_encode_type(Type, EnclosingNamespace)}
+  , {items, do_encode_type(Type, EnclosingNamespace, Opt)}
+  ];
+do_encode_type(#avro_array_type{ type   = Type
+                               , custom = CustomProps
+                               }, EnclosingNamespace, Opt) ->
+  [ {type,  encode_string(?AVRO_ARRAY)}
+  , {items, do_encode_type(Type, EnclosingNamespace, Opt)}
   | CustomProps
   ];
-do_encode_type(#avro_map_type{ type   = Type
-                             , custom = CustomProps
-                             }, EnclosingNamespace) ->
+do_encode_type(#avro_map_type{} = T, EnclosingNamespace,
+               #{canon := true} = Opt) ->
+  #avro_map_type{ type = Type
+                } = T,
   [ {type,   encode_string(?AVRO_MAP)}
-  , {values, do_encode_type(Type, EnclosingNamespace)}
+  , {values, do_encode_type(Type, EnclosingNamespace, Opt)}
+  ];
+do_encode_type(#avro_map_type{} = T, EnclosingNamespace, Opt) ->
+  #avro_map_type{ type   = Type
+                , custom = CustomProps
+                } = T,
+  [ {type,   encode_string(?AVRO_MAP)}
+  , {values, do_encode_type(Type, EnclosingNamespace, Opt)}
   | CustomProps
   ];
-do_encode_type(#avro_union_type{} = T, EnclosingNamespace) ->
+do_encode_type(#avro_union_type{} = T, EnclosingNamespace, Opt) ->
   Members = avro_union:get_types(T),
-  F = fun(Type) -> do_encode_type(Type, EnclosingNamespace) end,
+  F = fun(Type) -> do_encode_type(Type, EnclosingNamespace, Opt) end,
   lists:map(F, Members);
-do_encode_type(#avro_fixed_type{} = T, EnclosingNamespace) ->
+do_encode_type(#avro_fixed_type{} = T, _Ns, #{canon := true}) ->
+  #avro_fixed_type{ fullname  = Fullname
+                  , size      = Size
+                  } = T,
+  SchemaObjectFields =
+    [ {name, encode_string(Fullname)}
+    , {type, encode_string(?AVRO_FIXED)}
+    , {size, encode_integer(Size)}
+    ],
+  lists:flatten(SchemaObjectFields);
+do_encode_type(#avro_fixed_type{} = T, EnclosingNamespace, Opt) ->
   #avro_fixed_type{ name      = Name
                   , namespace = Namespace
                   , aliases   = Aliases
@@ -208,17 +269,23 @@ do_encode_type(#avro_fixed_type{} = T, EnclosingNamespace) ->
                   } = T,
   SchemaObjectFields =
     [ optional_field(namespace, ns(Namespace, EnclosingNamespace),
-                     ?NS_GLOBAL, fun encode_string/1)
-    , {type, encode_string(?AVRO_FIXED)}
+                     ?NS_GLOBAL, fun encode_string/1, Opt)
     , {name, encode_string(Name)}
+    , {type, encode_string(?AVRO_FIXED)}
     , {size, encode_integer(Size)}
-    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1)
+    , optional_field(aliases,   Aliases,   [], fun encode_aliases/1, Opt)
     | CustomProps
     ],
   lists:flatten(SchemaObjectFields).
 
 %% @private
-encode_field(Field, EnclosingNamespace) ->
+encode_field(Field, EnclosingNamespace, #{canon := true} = Opt) ->
+  #avro_record_field{ name    = Name
+                    , type    = Type} = Field,
+  [ {name, encode_string(Name)}
+  , {type, do_encode_type(Type, EnclosingNamespace, Opt)}
+  ];
+encode_field(Field, EnclosingNamespace, Opt) ->
   #avro_record_field{ name    = Name
                     , doc     = Doc
                     , type    = Type
@@ -226,12 +293,12 @@ encode_field(Field, EnclosingNamespace) ->
                     , order   = Order
                     , aliases = Aliases} = Field,
   [ {name, encode_string(Name)}
-  , {type, do_encode_type(Type, EnclosingNamespace)}
+  , {type, do_encode_type(Type, EnclosingNamespace, Opt)}
   ]
-  ++ optional_field(default, Default, ?NO_VALUE, fun(X) -> ?INLINE(X) end)
-  ++ optional_field(doc,     Doc,     ?NO_DOC,   fun encode_string/1)
-  ++ optional_field(order,   Order,   ascending, fun encode_order/1)
-  ++ optional_field(aliases, Aliases, [],        fun encode_aliases/1).
+  ++ optional_field(default, Default, ?NO_VALUE, fun(X) -> ?INLINE(X) end, Opt)
+  ++ optional_field(doc,     Doc,     ?NO_DOC,   fun encode_string/1, Opt)
+  ++ optional_field(order,   Order,   ascending, fun encode_order/1, Opt)
+  ++ optional_field(aliases, Aliases, [],        fun encode_aliases/1, Opt).
 
 %% @private Get namespace to encode.
 %% Ignore namespace to encode if it is the same as enclosing namesapce

--- a/test/avro_json_encoder_canon_tests.erl
+++ b/test/avro_json_encoder_canon_tests.erl
@@ -1,0 +1,154 @@
+%% coding: latin-1
+%%%-------------------------------------------------------------------
+%%% Copyright (c) 2018 Klarna AB
+%%%
+%%% This file is provided to you under the Apache License,
+%%% Version 2.0 (the "License"); you may not use this file
+%%% except in compliance with the License.  You may obtain
+%%% a copy of the License at
+%%%
+%%%   http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing,
+%%% software distributed under the License is distributed on an
+%%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%%% KIND, either express or implied.  See the License for the
+%%% specific language governing permissions and limitations
+%%% under the License.
+%%%-------------------------------------------------------------------
+-module(avro_json_encoder_canon_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+canon(Json) ->
+  Schema = avro_json_decoder:decode_schema(Json),
+  avro:encode_schema(Schema, [{canon, true}]).
+
+% Run Java test cases from the Avro project:
+% https://github.com/apache/avro/blob/master/share/test/data/schema-tests.txt
+
+java_primitive_test() ->
+  ?assertEqual(<<"\"null\"">>, canon(<<"\"null\"">>)),                % 000
+  ?assertEqual(<<"\"null\"">>, canon(<<"{\"type\":\"null\"}">>)),     % 001
+  ?assertEqual(<<"\"boolean\"">>, canon(<<"\"boolean\"">>)),          % 002
+  ?assertEqual(<<"\"boolean\"">>, canon(<<"{\"type\":\"boolean\"}">>)), % 003
+  ?assertEqual(<<"\"int\"">>, canon(<<"\"int\"">>)),                  % 004
+  ?assertEqual(<<"\"int\"">>, canon(<<"{\"type\":\"int\"}">>)),       % 005
+  ?assertEqual(<<"\"long\"">>,canon(<<"\"long\"">>)),                 % 006
+  ?assertEqual(<<"\"long\"">>, canon(<<"{\"type\":\"long\"}">>)),     % 007
+  ?assertEqual(<<"\"float\"">>, canon(<<"\"float\"">>)),              % 008
+  ?assertEqual(<<"\"float\"">>, canon(<<"{\"type\":\"float\"}">>)),   % 009
+  ?assertEqual(<<"\"double\"">>, canon(<<"\"double\"">>)),            % 010
+  ?assertEqual(<<"\"double\"">>, canon(<<"{\"type\":\"double\"}">>)), % 011
+  ?assertEqual(<<"\"bytes\"">>, canon(<<"\"bytes\"">>)),              % 012
+  ?assertEqual(<<"\"bytes\"">>, canon(<<"{\"type\":\"bytes\"}">>)),   % 013
+  ?assertEqual(<<"\"string\"">>, canon(<<"\"string\"">>)),            % 014
+  ?assertEqual(<<"\"string\"">>, canon(<<"{\"type\":\"string\"}">>)), % 015
+  % avro_json_decoder:decode_schema/1 considers empty enum invalid
+  % ?assertEqual(<<"[]">>, canon(<<"[  ]">>)),                        % 016
+  ?assertEqual(<<"[\"int\"]">>, canon(<<"[ \"int\"  ]">>)),           % 017
+  ?assertEqual(<<"[\"int\",\"boolean\"]">>,
+               canon(<<"[ \"int\" , {\"type\":\"boolean\"} ]">>)).    % 018
+
+% Put fields in standard order, without whitespace
+java_019_test() ->
+  ?assertEqual(<<"{\"name\":\"foo\",\"type\":\"record\",\"fields\":[]}">>,
+               canon(<<"{\"fields\":[], "
+                       "\"type\":\"record\", \"name\":\"foo\"}">>)).
+
+java_020_test() ->
+  ?assertEqual(<<"{\"name\":\"x.y.foo\",\"type\":\"record\",\"fields\":[]}">>,
+               canon(<<"{\"fields\":[], \"type\":\"record\", \"name\":\"foo\", "
+                       "\"namespace\":\"x.y\"}">>)).
+
+java_021_test() ->
+% https://avro.apache.org/docs/1.8.2/spec.html#names
+%
+% "A fullname is specified. If the name specified contains a dot, then it is
+% assumed to be a fullname, and any namespace also specified is ignored. For
+% example, use "name": "org.foo.X" to indicate the fullname org.foo.X."
+  ?assertEqual(<<"{\"name\":\"a.b.foo\",\"type\":\"record\",\"fields\":[]}">>,
+               canon(<<"{\"fields\":[], \"type\":\"record\", "
+                       "\"name\":\"a.b.foo\", \"namespace\":\"x.y\"}">>)).
+
+java_022_test() ->
+  ?assertEqual(<<"{\"name\":\"foo\",\"type\":\"record\",\"fields\":[]}">>,
+               canon(<<"{\"fields\":[], \"type\":\"record\", "
+                       "\"name\":\"foo\", \"doc\":\"Useful info\"}">>)).
+
+java_023_test() ->
+  ?assertEqual(<<"{\"name\":\"foo\",\"type\":\"record\",\"fields\":[]}">>,
+               canon(<<"{\"fields\":[], \"type\":\"record\", "
+                       "\"name\":\"foo\", \"aliases\":[\"foo\",\"bar\"]}">>)).
+
+java_024_test() ->
+  ?assertEqual(canon(<<"{\"fields\":[], \"type\":\"record\", "
+                       "\"name\":\"foo\", \"doc\":\"foo\", "
+                       "\"aliases\":[\"foo\",\"bar\"]}">>),
+               <<"{\"name\":\"foo\",\"type\":\"record\",\"fields\":[]}">>).
+
+java_025_test() ->
+  ?assertEqual(<<"{\"name\":\"foo\",\"type\":\"record\",\"fields\":["
+                 "{\"name\":\"f1\",\"type\":\"boolean\"}]}">>,
+               canon(<<"{\"fields\":[{\"type\":{\"type\":\"boolean\"}, "
+                       "\"name\":\"f1\"}], \"type\":\"record\", "
+                       "\"name\":\"foo\"}">>)).
+
+java_026_test() ->
+  Result = canon(<<
+    "{ \"fields\":[{\"type\":\"boolean\", \"aliases\":[], \"name\":\"f1\", "
+    "\"default\":true},", 10:8,
+    "            {\"order\":\"descending\",\"name\":\"f2\",\"doc\":\"Hello\","
+    "\"type\":\"int\"}],", 10:8,
+    "  \"type\":\"record\", \"name\":\"foo\"", 10:8,
+    "}", 10:8
+                 >>),
+  Expected = <<"{\"name\":\"foo\",\"type\":\"record\",\"fields\":["
+               "{\"name\":\"f1\",\"type\":\"boolean\"},"
+               "{\"name\":\"f2\",\"type\":\"int\"}]}">>,
+  ?assertEqual(Expected, Result).
+
+java_027_test() ->
+  ?assertEqual(<<"{\"name\":\"foo\",\"type\":\"enum\","
+                 "\"symbols\":[\"A1\"]}">>,
+               canon(<<"{\"type\":\"enum\", \"name\":\"foo\", "
+                       "\"symbols\":[\"A1\"]}">>)).
+
+java_028_test() ->
+  ?assertEqual(<<"{\"name\":\"x.y.z.foo\",\"type\":\"enum\","
+                 "\"symbols\":[\"A1\",\"A2\"]}">>,
+               canon(<<"{\"namespace\":\"x.y.z\", \"type\":\"enum\", "
+                       "\"name\":\"foo\", \"doc\":\"foo bar\", "
+                       "\"symbols\":[\"A1\", \"A2\"]}">>)).
+
+java_029_test() ->
+  ?assertEqual(<<"{\"name\":\"foo\",\"type\":\"fixed\",\"size\":15}">>,
+               canon(<<"{\"name\":\"foo\",\"type\":\"fixed\",\"size\":15}">>)).
+
+java_030_test() ->
+  ?assertEqual(<<"{\"name\":\"x.y.z.foo\",\"type\":\"fixed\",\"size\":32}">>,
+               canon(<<"{\"namespace\":\"x.y.z\", \"type\":\"fixed\", "
+                       "\"name\":\"foo\", \"doc\":\"foo bar\", \"size\":32}">>)).
+
+java_031_test() ->
+  ?assertEqual(<<"{\"type\":\"array\",\"items\":\"null\"}">>,
+               canon(<<"{ \"items\":{\"type\":\"null\"}, "
+                       "\"type\":\"array\"}">>)).
+
+java_032_test() ->
+  ?assertEqual(canon(<<"{ \"values\":\"string\", \"type\":\"map\"}">>),
+               <<"{\"type\":\"map\",\"values\":\"string\"}">>).
+
+java_033_test() ->
+  ?assertEqual(<<"{\"name\":\"PigValue\",\"type\":\"record\",\"fields\":["
+                 "{\"name\":\"value\",\"type\":[\"null\",\"int\",\"long\","
+                 "\"PigValue\"]}]}">>,
+     canon(<<"  {\"name\":\"PigValue\",\"type\":\"record\",", 10:8,
+             "   \"fields\":[{\"name\":\"value\", \"type\":[\"null\", "
+             "\"int\", \"long\", \"PigValue\"]}]}", 10:8>>)).
+
+%%%_* Emacs ====================================================================
+%%% Local Variables:
+%%% allout-layout: t
+%%% erlang-indent-level: 2
+%%% End:

--- a/test/avro_json_encoder_tests.erl
+++ b/test/avro_json_encoder_tests.erl
@@ -128,8 +128,8 @@ encode_record_type_test() ->
   Json = encode_type(sample_record_type()),
   ?assertEqual(<<"{"
   "\"namespace\":\"com.klarna.test.bix\","
-  "\"type\":\"record\","
   "\"name\":\"SampleRecord\","
+  "\"type\":\"record\","
   "\"doc\":\"Record documentation\","
   "\"fields\":["
   "{\"name\":\"bool\","
@@ -181,8 +181,8 @@ encode_enum_type_test() ->
   EnumTypeJson = encode_type(EnumType),
   ?assertEqual(<<"{"
   "\"namespace\":\"com.klarna.test.bix\","
-  "\"type\":\"enum\","
   "\"name\":\"Enum\","
+  "\"type\":\"enum\","
   "\"symbols\":[\"A\",\"B\",\"C\"]"
   "}">>, EnumTypeJson).
 
@@ -251,8 +251,8 @@ encode_fixed_type_test() ->
   Json = encode_type(Type),
   ?assertEqual(<<"{"
   "\"namespace\":\"name.space\","
-  "\"type\":\"fixed\","
   "\"name\":\"FooBar\","
+  "\"type\":\"fixed\","
   "\"size\":2,"
   "\"aliases\":[\"name.space.Alias1\",\"name.space.Alias2\"]}">>, Json).
 
@@ -339,8 +339,8 @@ encode_type_shortname_ref_test() ->
   Encoded = encode_type(Type),
   Expected =
     <<"{\"namespace\":\"com.example\","
-       "\"type\":\"record\","
        "\"name\":\"rec\","
+       "\"type\":\"record\","
        "\"fields\":[{\"name\":\"f1\",\"type\":\"mytype\"}]}">>,
   ?assertEqual(Expected, iolist_to_binary(Encoded)).
 
@@ -351,13 +351,13 @@ encode_type_no_redundant_ns_test() ->
   Field = avro_record:define_field("f", SubType, []),
   Type = avro_record:type("rec", [Field], [{namespace, "com.example"}]),
   Encoded = encode_type(Type),
-  SubJSON = ["{\"type\":\"record\","
-              "\"name\":\"subrec\","
+  SubJSON = ["{\"name\":\"subrec\","
+              "\"type\":\"record\","
               "\"fields\":[{\"name\":\"subf\",\"type\":\"int\"}]}"],
   Expected =
     ["{\"namespace\":\"com.example\","
-      "\"type\":\"record\","
       "\"name\":\"rec\","
+      "\"type\":\"record\","
       "\"fields\":"
           "[{\"name\":\"f\","
             "\"type\":", SubJSON,
@@ -376,8 +376,8 @@ encode_field_order_test_() ->
           end,
         Expected =
            ["{\"namespace\":\"com.example\","
-             "\"type\":\"record\","
              "\"name\":\"rec\","
+             "\"type\":\"record\","
              "\"fields\":[{\"name\":\"f\","
                           "\"type\":\"mytype\"",
                           EncodedOrder,


### PR DESCRIPTION
Add an option to generate schemas in Parsing Canonical Form as defined here: https://avro.apache.org/docs/1.8.2/spec.html#Parsing+Canonical+Form+for+Schemas

I believe this patch addresses all the issues in https://avro.apache.org/docs/1.8.2/spec.html#Transforming+into+Parsing+Canonical+Form,
though it doesn't do anything with encoding of STRINGS.