### PR TITLE
Add compatibility macros to support new stacktrace handling in Erlang 21

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,5 +16,5 @@
    - Support Parsing Canonical Form for Schemas (contributer congini/@reachfh)
 * 2.6.1
    - Allow `"null"` string as default value for 'null' type in union type record fields (contributer bka9)
-
-
+* 2.6.2
+   - Support Erlang 21.0 stacktraces

--- a/include/avro_internal.hrl
+++ b/include/avro_internal.hrl
@@ -182,7 +182,7 @@
 -define(ENC_ERR(Reason, Context),
         {'$avro_encode_error', Reason, Context}).
 
--define(RAISE_ENC_ERR(EXCEPTION_CLASS, EXCEPTION_REASON, THIS_CONTEXT),
+-define(RAISE_ENC_ERR(EXCEPTION_CLASS, EXCEPTION_REASON, THIS_CONTEXT, STACK),
         begin
           {Reason, Context} =
             case EXCEPTION_REASON of
@@ -191,7 +191,7 @@
               _ ->
                 {EXCEPTION_REASON, THIS_CONTEXT}
             end,
-          erlang:raise(EXCEPTION_CLASS, ?ENC_ERR(Reason, Context), ?GET_STACKTRACE)
+          erlang:raise(EXCEPTION_CLASS, ?ENC_ERR(Reason, Context), STACK)
         end).
 -endif.
 

--- a/include/avro_internal.hrl
+++ b/include/avro_internal.hrl
@@ -20,6 +20,7 @@
 -define(AVRO_INTERNAL_HRL, true).
 
 -include("erlavro.hrl").
+-include("avro_stacktrace.hrl").
 
 -define(INT4_MIN, -2147483648).
 -define(INT4_MAX,  2147483647).
@@ -183,7 +184,6 @@
 
 -define(RAISE_ENC_ERR(EXCEPTION_CLASS, EXCEPTION_REASON, THIS_CONTEXT),
         begin
-          Stack = erlang:get_stacktrace(),
           {Reason, Context} =
             case EXCEPTION_REASON of
               ?ENC_ERR(ReasonX, ContextX) ->
@@ -191,7 +191,7 @@
               _ ->
                 {EXCEPTION_REASON, THIS_CONTEXT}
             end,
-          erlang:raise(EXCEPTION_CLASS, ?ENC_ERR(Reason, Context), Stack)
+          erlang:raise(EXCEPTION_CLASS, ?ENC_ERR(Reason, Context), ?GET_STACKTRACE)
         end).
 -endif.
 

--- a/include/avro_stacktrace.hrl
+++ b/include/avro_stacktrace.hrl
@@ -35,8 +35,8 @@
 -define(CAPTURE_STACKTRACE, ).
 -define(GET_STACKTRACE, erlang:get_stacktrace()).
 -else.
--define(CAPTURE_STACKTRACE, :__StackTrace).
--define(GET_STACKTRACE, __StackTrace).
+-define(CAPTURE_STACKTRACE, :MacroStackTrace).
+-define(GET_STACKTRACE, MacroStackTrace).
 -endif.
 
 %%%_* Emacs ====================================================================

--- a/include/avro_stacktrace.hrl
+++ b/include/avro_stacktrace.hrl
@@ -1,0 +1,46 @@
+%%%-----------------------------------------------------------------------------
+%%% Copyright (c) 2013-2018 Klarna AB
+%%%
+%%% This file is provided to you under the Apache License,
+%%% Version 2.0 (the "License"); you may not use this file
+%%% except in compliance with the License.  You may obtain
+%%% a copy of the License at
+%%%
+%%%   http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing,
+%%% software distributed under the License is distributed on an
+%%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%%% KIND, either express or implied.  See the License for the
+%%% specific language governing permissions and limitations
+%%% under the License.
+%%%-----------------------------------------------------------------------------
+
+%% erlang:get_stacktrace/1 is deprecated by http://erlang.org/eeps/eep-0047.md
+%% This file provides macros to support source code compaibility with old and
+%% new ways of doing things.
+
+-type stack_item() :: {Module :: module(),
+                       Function :: atom(),
+                       Arity :: arity() | (Args :: [term()]),
+                       Location :: [{file, Filename :: string()} |
+                                    {line, Line :: pos_integer()}]}.
+%% An item in a stack back-trace.
+%%
+%% Note that the `erlang' module already defines the same `stack_item/0' type,
+%% but it is not exported from the module.
+%% So, maybe as a temporary measure, we redefine this type for passing full dialyzer analysis.
+
+-ifdef('FUN_STACKTRACE').
+-define(CAPTURE_STACKTRACE, ).
+-define(GET_STACKTRACE, erlang:get_stacktrace()).
+-else.
+-define(CAPTURE_STACKTRACE, :__StackTrace).
+-define(GET_STACKTRACE, __StackTrace).
+-endif.
+
+%%%_* Emacs ====================================================================
+%%% Local Variables:
+%%% allout-layout: t
+%%% erlang-indent-level: 2
+%%% End:

--- a/include/avro_stacktrace.hrl
+++ b/include/avro_stacktrace.hrl
@@ -1,5 +1,5 @@
 %%%-----------------------------------------------------------------------------
-%%% Copyright (c) 2013-2018 Klarna AB
+%%% Copyright (c) 2018 Klarna AB
 %%%
 %%% This file is provided to you under the Apache License,
 %%% Version 2.0 (the "License"); you may not use this file
@@ -19,17 +19,6 @@
 %% erlang:get_stacktrace/1 is deprecated by http://erlang.org/eeps/eep-0047.md
 %% This file provides macros to support source code compaibility with old and
 %% new ways of doing things.
-
--type stack_item() :: {Module :: module(),
-                       Function :: atom(),
-                       Arity :: arity() | (Args :: [term()]),
-                       Location :: [{file, Filename :: string()} |
-                                    {line, Line :: pos_integer()}]}.
-%% An item in a stack back-trace.
-%%
-%% Note that the `erlang' module already defines the same `stack_item/0' type,
-%% but it is not exported from the module.
-%% So, maybe as a temporary measure, we redefine this type for passing full dialyzer analysis.
 
 -ifdef('FUN_STACKTRACE').
 -define(CAPTURE_STACKTRACE, ).

--- a/rebar.config
+++ b/rebar.config
@@ -10,6 +10,7 @@
 {xref_checks,          [ undefined_function_calls
                        , deprecated_function_calls
                        ]}.
+{edoc_opts,           [{preprocess, true}]}.
 {deps,
  [ {jsone, "1.4.3"}
  ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,7 @@
 {erl_opts,             [ debug_info
                        , warnings_as_errors
                        , {d,'NOTEST'}
+                       , {platform_define, "^(R|1|20)", 'FUN_STACKTRACE'}
                        ]}.
 {eunit_opts,           [verbose]}.
 {cover_enabled,        true}.

--- a/src/avro_decoder_hooks.erl
+++ b/src/avro_decoder_hooks.erl
@@ -173,7 +173,9 @@ print_trace_on_failure(T, Sub, Data, DecodeFun, PrintFun, HistCount) ->
   ok = add_hist({push, Name, Sub}),
   try
     decode_and_add_trace(Sub, Data, DecodeFun)
-  catch C : R ?CAPTURE_STACKTRACE when not (is_tuple(R) andalso element(1, R) =:= ?REASON_TAG) ->
+  catch
+    C : R ?CAPTURE_STACKTRACE
+      when not (is_tuple(R) andalso element(1, R) =:= ?REASON_TAG) ->
     %% catch only the very first error
     ok = print_trace(PrintFun, HistCount),
     ok = erase_hist(),

--- a/src/avro_decoder_hooks.erl
+++ b/src/avro_decoder_hooks.erl
@@ -68,6 +68,7 @@
         ]).
 
 -include("erlavro.hrl").
+-include("avro_stacktrace.hrl").
 
 -define(PD_PP_INDENTATION, '$avro_decoder_pp_indentation').
 -define(PD_DECODER_HIST, '$avro_decoder_hist').
@@ -172,12 +173,11 @@ print_trace_on_failure(T, Sub, Data, DecodeFun, PrintFun, HistCount) ->
   ok = add_hist({push, Name, Sub}),
   try
     decode_and_add_trace(Sub, Data, DecodeFun)
-  catch C : R when not (is_tuple(R) andalso element(1, R) =:= ?REASON_TAG) ->
+  catch C : R ?CAPTURE_STACKTRACE when not (is_tuple(R) andalso element(1, R) =:= ?REASON_TAG) ->
     %% catch only the very first error
-    Stack = erlang:get_stacktrace(),
     ok = print_trace(PrintFun, HistCount),
     ok = erase_hist(),
-    erlang:raise(C, {?REASON_TAG, R}, Stack)
+    erlang:raise(C, {?REASON_TAG, R}, ?GET_STACKTRACE)
   end.
 
 %% @private

--- a/src/avro_map.erl
+++ b/src/avro_map.erl
@@ -116,7 +116,7 @@ encode(Type, Value, EncodeFun) ->
                 try
                   EncodeFun(ItemsType, K, V)
                 catch
-                  C : E ->
+                  C : E ?CAPTURE_STACKTRACE ->
                     ?RAISE_ENC_ERR(C, E, [{map, Type},
                                           {key, K}])
                 end

--- a/src/avro_map.erl
+++ b/src/avro_map.erl
@@ -118,7 +118,7 @@ encode(Type, Value, EncodeFun) ->
                 catch
                   C : E ?CAPTURE_STACKTRACE ->
                     ?RAISE_ENC_ERR(C, E, [{map, Type},
-                                          {key, K}])
+                                          {key, K}], ?GET_STACKTRACE)
                 end
             end, Value).
 

--- a/src/avro_record.erl
+++ b/src/avro_record.erl
@@ -336,7 +336,7 @@ encode(#avro_record_type{ fields = FieldDefs
         catch
           C : E ?CAPTURE_STACKTRACE ->
             ?RAISE_ENC_ERR(C, E, [{record, FullName},
-                                  {field, FieldName}])
+                                  {field, FieldName}], ?GET_STACKTRACE)
         end
     end, FieldDefs).
 

--- a/src/avro_record.erl
+++ b/src/avro_record.erl
@@ -219,13 +219,12 @@ do_default(FullName, FieldName, DoFun, Value) ->
   try
     DoFun(Value)
   catch
-    error : Reason ->
-      Stack = erlang:get_stacktrace(),
+    error : Reason ?CAPTURE_STACKTRACE ->
       Context = [ {record, FullName}
                 , {field, FieldName}
                 , {reason, Reason}
                 ],
-      erlang:raise(error, {bad_default, Context}, Stack)
+      erlang:raise(error, {bad_default, Context}, ?GET_STACKTRACE)
   end.
 
 %% @private default value for a union type should be type checked by the
@@ -335,7 +334,7 @@ encode(#avro_record_type{ fields = FieldDefs
           Value =:= ?NO_VALUE andalso erlang:error(required_field_missed),
           EncodeFun(FieldName, FieldType, Value)
         catch
-          C : E ->
+          C : E ?CAPTURE_STACKTRACE ->
             ?RAISE_ENC_ERR(C, E, [{record, FullName},
                                   {field, FieldName}])
         end

--- a/src/erlavro.app.src
+++ b/src/erlavro.app.src
@@ -1,7 +1,7 @@
 {application, erlavro,
   [
     {description, "Apache Avro support for Erlang/Elixir"},
-    {vsn, "2.6.1"},
+    {vsn, "2.6.2"},
     {registered, []},
     {applications, [
       kernel,


### PR DESCRIPTION
Erlang 21 implements a new way of handling stacktraces, as described in [EEP 47](http://erlang.org/eeps/eep-0047.md). It also deprecates `erlang:get_stacktrace/1`, resulting in warnings, which cause the build to fail due to `warnings_as_errors`. 

This PR adds compatibility macros which avoid the warning and support old and new ways of getting the stacktrace.