### PR TITLE
Update jsone from 1.4.3 to 1.4.6 to be compatible with erlang 21

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,5 @@
                        ]}.
 {edoc_opts,           [{preprocess, true}]}.
 {deps,
- [ {jsone, "1.4.3"}
+ [ {jsone, "1.4.6"}
  ]}.


### PR DESCRIPTION
Jake fotgot to update rebar.config. jsone 1.4.3 is to compatible with erlang 21 because the old version   use deprecated stacktrace function.

![image](https://user-images.githubusercontent.com/20479699/41756149-74357e10-760d-11e8-919d-2258c5382d72.png)
