### PR TITLE
Refine macros for get_stacktrace deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,22 @@ notifications:
   email: false
 
 otp_release:
-  - 20.0
+  - 21.0
+  - 20.3
   - 19.3
-  - 18.1
-  - 17.4
 
 script:
   - make elvis-rock
-  - make
-  - make eunit
   - make edoc
   - make xref
-  - if [ "$(erl -noshell -eval 'io:format(erlang:system_info(otp_release)), halt(0)')" -gt 18 ]; then make dialyzer; fi
-  - make cover
+  - make eunit
+  - |
+    OTP_RELEASE=`erl -noshell -eval 'io:format(erlang:system_info(otp_release)), halt(0)'`
+    if [ $OTP_RELEASE -eq 21 ]; then
+      make dialyzer
+      make cover
+      make coveralls
+    else
+      make cover
+    fi
 

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,6 @@ hex-publish: clean
 cover:
 	$(REBAR) cover -v
 
+.PHONY: coveralls
+coveralls:
+	$(REBAR) coveralls send

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Current version implements Apache Avro 1.8.1 specification.
 
 License: Apache License 2.0
 
-[![Build Status](https://travis-ci.org/klarna/erlavro.svg?branch=master)](https://travis-ci.org/klarna/erlavro)
+[![Build Status](https://travis-ci.org/klarna/erlavro.svg?branch=master)](https://travis-ci.org/klarna/erlavro) [![Coverage Status](https://coveralls.io/repos/github/klarna/erlavro/badge.svg?branch=master)](https://coveralls.io/github/klarna/erlavro?branch=master)
 
 # Avro Type and Erlang Spec Mapping
 

--- a/changelog.md
+++ b/changelog.md
@@ -22,3 +22,5 @@
    - Upgrade jsone from 1.4.3 to 1.4.6 (for OTP-21)
 * 2.6.4
    - Do not conditionally export functions
+* 2.6.5
+   - Refine macros for `get_stacktrace` deprecation

--- a/include/avro_stacktrace.hrl
+++ b/include/avro_stacktrace.hrl
@@ -20,7 +20,7 @@
 %% This file provides macros to support source code compaibility with old and
 %% new ways of doing things.
 
--ifdef('FUN_STACKTRACE').
+-ifndef(OTP_RELEASE).
 -define(CAPTURE_STACKTRACE, ).
 -define(GET_STACKTRACE, erlang:get_stacktrace()).
 -else.

--- a/rebar.config
+++ b/rebar.config
@@ -2,11 +2,8 @@
 {erl_opts,             [ debug_info
                        , warnings_as_errors
                        , {d,'NOTEST'}
-                       , {platform_define, "^(R|1|20)", 'FUN_STACKTRACE'}
                        ]}.
 {eunit_opts,           [verbose]}.
-{cover_enabled,        true}.
-{cover_opts,           [verbose]}.
 {xref_checks,          [ undefined_function_calls
                        , deprecated_function_calls
                        ]}.
@@ -14,3 +11,7 @@
 {deps,
  [ {jsone, "1.4.6"}
  ]}.
+
+{cover_opts, [verbose]}.
+{cover_enabled, true}.
+{cover_export_enabled, true}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,8 +1,19 @@
 IsRebar3 = erlang:function_exported(rebar3, main, 1),
 
+CONFIG0 = case os:getenv("TRAVIS") of
+  "true" ->
+    JobId   = os:getenv("TRAVIS_JOB_ID"),
+    [{coveralls_service_job_id, JobId},
+     {plugins, [coveralls]},
+     {coveralls_coverdata, "_build/test/cover/eunit.coverdata"},
+     {coveralls_service_name , "travis-ci"} | CONFIG];
+  _ ->
+    CONFIG
+end.
+
 case IsRebar3 of
     true ->
-        CONFIG;
+        CONFIG0;
     false ->
         Rebar3Deps = proplists:get_value(deps, CONFIG),
         Rebar2Deps = [

--- a/src/avro.erl
+++ b/src/avro.erl
@@ -115,6 +115,7 @@
             | boolean()
             | integer()
             | float()
+            | binary()
             | iolist()
             | [avro:in()]
             | [{name_raw(), avro:in()}].

--- a/src/avro_json_decoder.erl
+++ b/src/avro_json_decoder.erl
@@ -145,7 +145,6 @@ decode_value(JsonValue, Schema, StoreOrLkupFun, Options) ->
 
 %%%_* Internal functions =======================================================
 
-%% @private
 -spec parse_schema(json_value()) -> avro_type() | no_return().
 parse_schema(?JSON_OBJ(Attrs)) ->
   %% Json object: this is a complex type definition (except for unions)
@@ -164,7 +163,7 @@ parse_schema(Name) when ?IS_NAME(Name) ->
     Name
   end.
 
-%% @private Parse JSON object to avro type definition.
+%% Parse JSON object to avro type definition.
 -spec parse_type([{binary(), json_value()}]) -> avro_type() | no_return().
 parse_type(Attrs) ->
   case avro_util:get_opt(<<"type">>, Attrs) of
@@ -183,7 +182,6 @@ parse_type(Attrs) ->
       primitive_type(Name, CustomProps)
   end.
 
-%% @private
 -spec primitive_type(name(), [custom_prop()]) ->
         primitive_type() | no_return().
 primitive_type(Name, CustomProps) when ?IS_AVRO_PRIMITIVE_NAME(Name) ->
@@ -191,7 +189,6 @@ primitive_type(Name, CustomProps) when ?IS_AVRO_PRIMITIVE_NAME(Name) ->
 primitive_type(Name, _CustomProps) ->
   erlang:error({unknown_type, Name}).
 
-%% @private
 -spec parse_record_type([{binary(), json_value()}]) ->
         record_type() | no_return().
 parse_record_type(Attrs) ->
@@ -209,14 +206,12 @@ parse_record_type(Attrs) ->
                    | Custom
                    ]).
 
-%% @private
 -spec parse_record_fields([{name(), json_value()}]) ->
         [record_field()] | no_return().
 parse_record_fields(Fields) ->
   lists:map(fun(?JSON_OBJ(FieldAttrs)) -> parse_record_field(FieldAttrs) end,
             Fields).
 
-%% @private
 -spec parse_record_field([{binary(), json_value()}]) ->
         record_field() | no_return().
 parse_record_field(Attrs) ->
@@ -236,13 +231,11 @@ parse_record_field(Attrs) ->
   , aliases = parse_aliases(Aliases)
   }.
 
-%% @private
 -spec parse_order(binary()) -> ascending | descending | ignore.
 parse_order(<<"ascending">>)  -> ascending;
 parse_order(<<"descending">>) -> descending;
 parse_order(<<"ignore">>)     -> ignore.
 
-%% @private
 -spec parse_enum_type([{binary(), json_value()}]) -> enum_type().
 parse_enum_type(Attrs) ->
   NameBin = avro_util:get_opt(<<"name">>,      Attrs),
@@ -259,26 +252,22 @@ parse_enum_type(Attrs) ->
                  | Custom
                  ]).
 
-%% @private
 -spec parse_enum_symbols([binary()]) -> [enum_symbol()].
 parse_enum_symbols([_|_] = SymbolsArray) ->
   SymbolsArray.
 
-%% @private
 -spec parse_array_type([{binary(), json_value()}]) -> array_type().
 parse_array_type(Attrs) ->
   Items  = avro_util:get_opt(<<"items">>, Attrs),
   Custom = filter_custom_props(Attrs, [<<"items">>]),
   avro_array:type(parse_schema(Items), Custom).
 
-%% @private
 -spec parse_map_type([{binary(), json_value()}]) -> map_type().
 parse_map_type(Attrs) ->
   Values = avro_util:get_opt(<<"values">>, Attrs),
   Custom = filter_custom_props(Attrs, [<<"values">>]),
   avro_map:type(parse_schema(Values), Custom).
 
-%% @private
 -spec parse_fixed_type([{binary(), json_value()}]) -> fixed_type().
 parse_fixed_type(Attrs) ->
   NameBin = avro_util:get_opt(<<"name">>,      Attrs),
@@ -295,11 +284,9 @@ parse_fixed_type(Attrs) ->
                   | Custom
                   ]).
 
-%% @private
 -spec parse_fixed_size(integer()) -> pos_integer().
 parse_fixed_size(N) when is_integer(N) andalso N > 0 -> N.
 
-%% @private
 -spec parse_union_type(json_value()) -> union_type().
 parse_union_type(Attrs) ->
   Types = lists:map(
@@ -309,7 +296,6 @@ parse_union_type(Attrs) ->
             Attrs),
   avro_union:type(Types).
 
-%% @private
 -spec parse_aliases([name()]) -> [name()] | no_return().
 parse_aliases(AliasesArray) when is_list(AliasesArray) ->
   lists:map(
@@ -319,7 +305,6 @@ parse_aliases(AliasesArray) when is_list(AliasesArray) ->
     end,
     AliasesArray).
 
-%% @private
 -spec parse(json_value(), type_or_name(), lkup_fun(), boolean(), hook()) ->
         avro_value() | avro:out() | no_return().
 parse(Value, TypeName, Lkup, IsWrapped, Hook) when ?IS_NAME_RAW(TypeName) ->
@@ -361,7 +346,7 @@ parse(V, Type, Lkup, IsWrapped, Hook) when ?IS_MAP_TYPE(Type) ->
 parse(V, Type, Lkup, IsWrapped, Hook) when ?IS_UNION_TYPE(Type) ->
   parse_union(V, Type, Lkup, IsWrapped, Hook).
 
-%% @private Parse primitive values, return wrapped (boxed) value.
+%% Parse primitive values, return wrapped (boxed) value.
 -spec parse_prim(json_value(), avro_type()) -> avro_value().
 parse_prim(<<"null">>, Type) when ?IS_NULL_TYPE(Type) ->
     avro_primitive:null();
@@ -393,12 +378,10 @@ parse_prim(V, Type) when ?IS_STRING_TYPE(Type) andalso
                          is_binary(V) ->
   avro_primitive:string(V).
 
-%% @private
 -spec parse_bytes(binary()) -> binary().
 parse_bytes(BytesStr) ->
   list_to_binary(parse_bytes(BytesStr, [])).
 
-%% @private
 -spec parse_bytes(binary(), [byte()]) -> [byte()].
 parse_bytes(<<>>, Acc) ->
   lists:reverse(Acc);
@@ -406,7 +389,6 @@ parse_bytes(<<"\\u00", B1, B0, Rest/binary>>, Acc) ->
   Byte = erlang:list_to_integer([B1, B0], 16),
   parse_bytes(Rest, [Byte | Acc]).
 
-%% @private
 -spec parse_record(json_value(), record_type(),
                    lkup_fun(), boolean(), hook()) ->
         avro_value() | avro:out().
@@ -421,7 +403,6 @@ parse_record(?JSON_OBJ(Attrs), Type, Lkup, IsWrapped, Hook) ->
          end
        end).
 
-%% @private
 -spec convert_attrs_to_record_fields(json_value(), record_type(), lkup_fun(),
                                      boolean(), hook()) ->
         [{name(), avro_value() | avro:out()}] | no_return().
@@ -438,7 +419,6 @@ convert_attrs_to_record_fields(Attrs, Type, Lkup, IsWrapped, Hook) ->
     end,
     Attrs).
 
-%% @private
 -spec parse_array([json_value()], array_type(),
                   lkup_fun(), boolean(), hook()) ->
         [avro_value() | avro:out()].
@@ -464,7 +444,6 @@ parse_array(V, Type, Lkup, IsWrapped, Hook) when is_list(V) ->
       Items
   end.
 
-%% @private
 -spec parse_map(json_value(), map_type(), lkup_fun(), boolean(), hook()) ->
         avro_value() | avro:out().
 parse_map(?JSON_OBJ(Attrs), Type, Lkup, IsWrapped, Hook) ->
@@ -482,7 +461,6 @@ parse_map(?JSON_OBJ(Attrs), Type, Lkup, IsWrapped, Hook) ->
     false -> L
   end.
 
-%% @private
 -spec parse_union(json_value(), union_type(),
                   lkup_fun(), boolean(), hook()) ->
         avro_value() | avro:out() | no_return().
@@ -494,7 +472,6 @@ parse_union(?JSON_OBJ([{ValueTypeName, Value}]),
   %% Union value specified as {"type": <value>}
   parse_union_ex(ValueTypeName, Value, Type, Lkup, IsWrapped, Hook).
 
-%% @private
 -spec parse_union_ex(name(), json_value(), union_type(),
                      lkup_fun(), boolean(), hook()) ->
         avro_value() | avro:out() | no_return().
@@ -505,7 +482,6 @@ parse_union_ex(ValueTypeName, Value, UnionType, Lkup, IsWrapped, Hook) ->
                             Lkup, IsWrapped, Hook)
        end).
 
-%% @private
 -spec do_parse_union_ex(name(), json_value(), union_type(),
                         lkup_fun(), boolean(), hook()) ->
         avro_value() | avro:out() | no_return().
@@ -527,11 +503,11 @@ do_parse_union_ex(ValueTypeName, Value, UnionType,
       erlang:error({unknown_union_member, ValueTypeName})
   end.
 
-%% @private Always use tuple as object foramt.
+%% Always use tuple as object foramt.
 -spec decode_json(binary()) -> json_value().
 decode_json(JSON) -> jsone:decode(JSON, [{object_format, tuple}]).
 
-%% @private Filter out non-custom properties.
+%% Filter out non-custom properties.
 -spec filter_custom_props([{binary(), json_value()}], [name()]) ->
         [custom_prop()].
 filter_custom_props(Attrs, Keys0) ->

--- a/src/avro_ocf.erl
+++ b/src/avro_ocf.erl
@@ -236,7 +236,7 @@ decode_block(Lkup, Type, null, Bin, Count, Acc) ->
   {Obj, Tail} = decode_stream(Lkup, Type, Bin),
   decode_block(Lkup, Type, null, Tail, Count - 1, [Obj | Acc]).
 
-%% Hande coded schema.
+%% Hand coded schema.
 %% {"type": "record", "name": "org.apache.avro.file.Header",
 %% "fields" : [
 %%   {"name": "magic", "type": {"type": "fixed", "name": "Magic", "size": 4}},

--- a/src/erlavro.app.src
+++ b/src/erlavro.app.src
@@ -1,7 +1,7 @@
 {application, erlavro,
   [
     {description, "Apache Avro support for Erlang/Elixir"},
-    {vsn, "2.6.4"},
+    {vsn, "2.6.5"},
     {registered, []},
     {applications, [
       kernel,

--- a/test/avro_json_encoder_canon_tests.erl
+++ b/test/avro_json_encoder_canon_tests.erl
@@ -128,7 +128,8 @@ java_029_test() ->
 java_030_test() ->
   ?assertEqual(<<"{\"name\":\"x.y.z.foo\",\"type\":\"fixed\",\"size\":32}">>,
                canon(<<"{\"namespace\":\"x.y.z\", \"type\":\"fixed\", "
-                       "\"name\":\"foo\", \"doc\":\"foo bar\", \"size\":32}">>)).
+                       "\"name\":\"foo\", \"doc\":\"foo bar\", \"size\":32}">>
+                    )).
 
 java_031_test() ->
   ?assertEqual(<<"{\"type\":\"array\",\"items\":\"null\"}">>,


### PR DESCRIPTION
Make use of the OTP provided `OTP_RELEASE` macro instead of creating one from `platform_define` in rebar.config.
This should not require similar changes for Makefile projects.