### PR TITLE
Fix string unicode

### DIFF
--- a/src/avro_primitive.erl
+++ b/src/avro_primitive.erl
@@ -117,7 +117,7 @@ cast(Type, Value) when ?IS_BYTES_TYPE(Type) andalso
   {ok, ?AVRO_VALUE(Type, Value)};
 cast(Type, Value) when ?IS_STRING_TYPE(Type) andalso
                        (is_list(Value) orelse is_binary(Value)) ->
-  {ok, ?AVRO_VALUE(Type, erlang:iolist_to_binary(Value))};
+  {ok, ?AVRO_VALUE(Type,  unicode:characters_to_binary(Value))};
 cast(Type, Value) -> {error, {type_mismatch, Type, Value}}.
 
 %%%===================================================================


### PR DESCRIPTION
Existing code would fail the string represented as list contains non latin characters.
This fix uses unicode:characters_to_binary to allow that.
http://erlang.org/doc/apps/stdlib/unicode_usage.html#standard-unicode-representation