### PR TITLE
Support 'ojbect' as custom type properties

### DIFF
--- a/include/avro_internal.hrl
+++ b/include/avro_internal.hrl
@@ -65,8 +65,7 @@
 -type type_or_name() :: avro_type() | name_raw().
 
 -type custom_prop_name() :: binary().
-%% No plan to support recursive definition
--type custom_prop_value() :: number() | binary() | [binary()].
+-type custom_prop_value() :: jsone:json_value().
 -type custom_prop() :: {custom_prop_name(), custom_prop_value()}.
 
 -define(ASSIGNED_NAME, <<"_erlavro_assigned">>).

--- a/src/avro_json_decoder.erl
+++ b/src/avro_json_decoder.erl
@@ -507,7 +507,10 @@ do_parse_union_ex(ValueTypeName, Value, UnionType,
       erlang:error({unknown_union_member, ValueTypeName})
   end.
 
-%% Always use tuple as object foramt.
+%% Always use 'tuple' as object format.
+%% 'map' is a better option, but we have to keep it backward compatible.
+%% 'proplist' is not an option because otherwise there is no way to tell
+%% apart 'object' and 'array'.
 -spec decode_json(binary()) -> json_value().
 decode_json(JSON) -> jsone:decode(JSON, [{object_format, tuple}]).
 

--- a/src/erlavro.app.src
+++ b/src/erlavro.app.src
@@ -1,7 +1,7 @@
 {application, erlavro,
   [
     {description, "Apache Avro support for Erlang/Elixir"},
-    {vsn, "2.8.0"},
+    {vsn, "2.8.1"},
     {registered, []},
     {applications, [
       kernel,

--- a/test/avro_tests.erl
+++ b/test/avro_tests.erl
@@ -194,7 +194,7 @@ primitive_cast_error_test() ->
                    avro_primitive:int("foo")).
 
 get_custom_props_test() ->
-  Date = avro_primitive:type(int, [{logicalType, "Date"}, {"p", "v"}]),
+  Date = avro_primitive:type(int, [{logicalType, "Date"}, {"p", [{"x", "y"}]}]),
   Union = avro_union:type([null, int]),
   Array = avro_array:type(int, [{"p", "v"}, {tag, true}]),
   Enum = avro_enum:type("abc", ["a", "b", "c"], [{"p", "v"}]),
@@ -224,7 +224,7 @@ get_custom_props_test() ->
   ?assertEqual([], FieldTypeProps(k1)),
   ?assertEqual([], FieldTypeProps(k2)),
   ?assertEqual([{<<"logicalType">>, <<"Date">>},
-                {<<"p">>, <<"v">>}],
+                {<<"p">>, [{<<"x">>, <<"y">>}]}],
                FieldTypeProps(date)),
   ?assertEqual([{<<"p">>, <<"v">>}, {<<"tag">>, true}], FieldTypeProps(array)),
   ?assertEqual([{<<"p">>, <<"v">>}], FieldTypeProps(enum)),


### PR DESCRIPTION
Fixes #88 

Prior to this change, only primitive values are allowed as
custom type properties.  Now it can be a JSON object.