### PR TITLE
For string types, accept atoms as values

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,6 @@
    - Encode atom `nil` as "null" for Elixir consumers
 * 2.8.3
    - Allow arbitrary atoms in record_opt_name()
-* 2.8.4
-   - Encode atom values for string types
+* 2.9.0
+   - Encode atom values for string types when not nil or null
 

--- a/changelog.md
+++ b/changelog.md
@@ -37,3 +37,8 @@
    - Support 'object' as custom type properties
 * 2.8.2
    - Encode atom `nil` as "null" for Elixir consumers
+* 2.8.3
+   - Allow arbitrary atoms in record_opt_name()
+* 2.8.4
+   - Encode atom values for string types
+

--- a/priv/test.avsc
+++ b/priv/test.avsc
@@ -12,5 +12,6 @@
                   "default": [{"label": "default-label", "children": []}]}
                 ]}},
     {"name": "f2", "type": ["null", "string"], "default": null},
-    {"name": "f3", "type": ["null", "string"], "default": "null"}
+    {"name": "f3", "type": ["null", "string"], "default": "null"},
+    {"name": "f4", "type": ["string", "null"]}
    ]}

--- a/src/avro_primitive.erl
+++ b/src/avro_primitive.erl
@@ -122,7 +122,8 @@ cast(Type, Value) when ?IS_STRING_TYPE(Type) andalso
                        (is_list(Value) orelse is_binary(Value)) ->
   {ok, ?AVRO_VALUE(Type, erlang:iolist_to_binary(Value))};
 cast(Type, Value) when ?IS_STRING_TYPE(Type) andalso
-                       (is_atom(Value) andalso Value =/= null andalso Value =/= nil) ->
+                       (is_atom(Value) andalso
+                       (Value =/= null andalso Value =/= nil)) ->
   {ok, ?AVRO_VALUE(Type, erlang:atom_to_binary(Value, utf8))};
 cast(Type, Value) -> {error, {type_mismatch, Type, Value}}.
 

--- a/src/avro_primitive.erl
+++ b/src/avro_primitive.erl
@@ -121,6 +121,7 @@ cast(Type, Value) when ?IS_BYTES_TYPE(Type) andalso
 cast(Type, Value) when ?IS_STRING_TYPE(Type) andalso
                        (is_list(Value) orelse is_binary(Value)) ->
   {ok, ?AVRO_VALUE(Type, erlang:iolist_to_binary(Value))};
+% Encode atom values for string types when not null or nil
 cast(Type, Value) when ?IS_STRING_TYPE(Type) andalso
                        (is_atom(Value) andalso
                        (Value =/= null andalso Value =/= nil)) ->

--- a/src/avro_primitive.erl
+++ b/src/avro_primitive.erl
@@ -122,7 +122,7 @@ cast(Type, Value) when ?IS_STRING_TYPE(Type) andalso
                        (is_list(Value) orelse is_binary(Value)) ->
   {ok, ?AVRO_VALUE(Type, erlang:iolist_to_binary(Value))};
 cast(Type, Value) when ?IS_STRING_TYPE(Type) andalso
-                       is_atom(Value) ->
+                       (is_atom(Value) andalso Value =/= null andalso Value =/= nil) ->
   {ok, ?AVRO_VALUE(Type, erlang:atom_to_binary(Value, utf8))};
 cast(Type, Value) -> {error, {type_mismatch, Type, Value}}.
 

--- a/src/avro_primitive.erl
+++ b/src/avro_primitive.erl
@@ -121,6 +121,9 @@ cast(Type, Value) when ?IS_BYTES_TYPE(Type) andalso
 cast(Type, Value) when ?IS_STRING_TYPE(Type) andalso
                        (is_list(Value) orelse is_binary(Value)) ->
   {ok, ?AVRO_VALUE(Type, erlang:iolist_to_binary(Value))};
+cast(Type, Value) when ?IS_STRING_TYPE(Type) andalso
+                       is_atom(Value) ->
+  {ok, ?AVRO_VALUE(Type, erlang:atom_to_binary(Value, utf8))};
 cast(Type, Value) -> {error, {type_mismatch, Type, Value}}.
 
 %%%===================================================================

--- a/src/erlavro.app.src
+++ b/src/erlavro.app.src
@@ -1,7 +1,7 @@
 {application, erlavro,
   [
     {description, "Apache Avro support for Erlang/Elixir"},
-    {vsn, "2.8.2"},
+    {vsn, "2.9.0"},
     {registered, []},
     {applications, [
       kernel,

--- a/test/avro_binary_encoder_tests.erl
+++ b/test/avro_binary_encoder_tests.erl
@@ -212,6 +212,18 @@ encode_enum_properly_test() ->
   ?assertEqual(EncodedValue1, Encoded1),
   ?assertEqual(EncodedValue2, Encoded2).
 
+encode_enum_null_first_properly_test() ->
+  UnionType = avro_union:type([null, string]),
+  Value1 = avro_union:new(UnionType, avro_primitive:null()),
+  Value2 = avro_union:new(UnionType, avro_primitive:string("bar")),
+  EncodedValue1 = encode_value(Value1),
+  EncodedValue2 = encode_value(Value2),
+  Encoded1 = encode(fun(_) -> UnionType end, "some_union", null),
+  Encoded2 = encode(fun(_) -> UnionType end, "some_union", "bar"),
+  ?assertEqual(EncodedValue1, Encoded1),
+  ?assertEqual(EncodedValue2, Encoded2).
+
+
 encode_map_properly_test() ->
   Type = avro_map:type(int),
   TypedValue = avro_map:new(Type, [{"a", 3}, {"b", 27}]),

--- a/test/avro_tests.erl
+++ b/test/avro_tests.erl
@@ -388,7 +388,7 @@ default_values_test() ->
                            }]},
     Lkup(NodeTypeFullName)),
   %% Encode input has no 'children' field, default value should be used
-  Input = [{"f1", [{"label", "x"}]}],
+  Input = [{"f1", [{"label", "x"}]}, {"f4", "four"}],
   Expect = [{<<"f1">>, [ {<<"label">>, <<"x">>}
                        , {<<"children">>,
                           [ [ {<<"label">>, <<"default-label">>}
@@ -397,7 +397,8 @@ default_values_test() ->
                           ]}
                        ]},
             {<<"f2">>, null},
-            {<<"f3">>, null}],
+            {<<"f3">>, null},
+            {<<"f4">>, <<"four">>}],
   TestFun =
     fun(Opts) ->
       RootType = "org.apache.avro.test",
@@ -417,7 +418,7 @@ nil_values_test() ->
   Type = avro:decode_schema(JSON),
   Lkup = avro:make_lkup_fun(Type),
   %% Encode input has no 'children' field, default value should be used
-  Input = [{"f1", [{"label", "x"}]}, {"f2", nil}, {"f3", nil}],
+  Input = [{"f1", [{"label", "x"}]}, {"f2", nil}, {"f3", nil}, {"f4", nil}],
   Expect = [{<<"f1">>, [ {<<"label">>, <<"x">>}
                        , {<<"children">>,
                           [ [ {<<"label">>, <<"default-label">>}
@@ -426,7 +427,8 @@ nil_values_test() ->
                           ]}
                        ]},
             {<<"f2">>, null},
-            {<<"f3">>, null}],
+            {<<"f3">>, null},
+            {<<"f4">>, null}],
   TestFun =
     fun(Opts) ->
       RootType = "org.apache.avro.test",
@@ -446,7 +448,7 @@ atoms_as_strings_test() ->
   Type = avro:decode_schema(JSON),
   Lkup = avro:make_lkup_fun(Type),
   %% Encode input has no 'children' field, default value should be used
-  Input = [{"f1", [{"label", x}]}, {"f2", y}, {"f3", z}],
+  Input = [{"f1", [{"label", x}]}, {"f2", y}, {"f3", null}, {"f4", atom_value}],
   Expect = [{<<"f1">>, [ {<<"label">>, <<"x">>}
                        , {<<"children">>,
                           [ [ {<<"label">>, <<"default-label">>}
@@ -455,7 +457,8 @@ atoms_as_strings_test() ->
                           ]}
                        ]},
             {<<"f2">>, <<"y">>},
-            {<<"f3">>, <<"z">>}],
+            {<<"f3">>, null},
+            {<<"f4">>, <<"atom_value">>}],
   TestFun =
     fun(Opts) ->
       RootType = "org.apache.avro.test",
@@ -492,7 +495,7 @@ default_values_with_map_type_test() ->
                            }]},
     Lkup(NodeTypeFullName)),
   %% Encode input has no 'children' field, default value should be used
-  Input = #{"f1" => #{"label" => "x"}},
+  Input = #{"f1" => #{"label" => "x"}, "f4" => "four"},
   Expect = #{<<"f1">> =>
                #{
                  <<"label">> => <<"x">>,
@@ -503,7 +506,8 @@ default_values_with_map_type_test() ->
                    ]
                 },
              <<"f2">> => null,
-             <<"f3">> => null},
+             <<"f3">> => null,
+             <<"f4">> => <<"four">>},
   TestFun =
     fun(Opts) ->
       RootType = "org.apache.avro.test",


### PR DESCRIPTION
This PR adds functionality that allows string fields to accept atoms as values. I'm not sure if this is controversial in Erlang, but in Elixir it is very common to encode atom values as strings. For example, https://hexdocs.pm/jason/Jason.html#encode/2 happily encodes atom values as strings.

You can refer to this test example as well: https://github.com/michalmuskala/jason/blob/v1.1.2/test/encode_test.exs#L51

This has come up several times in projects where we are storing values as atoms, and we have to rewrite the value before passing it to the Avro encoder.

- [x] Properly encode union types (Test is broken)