### PR TITLE
Do not convert boolean atoms to strings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,5 +40,7 @@
 * 2.8.3
    - Allow arbitrary atoms in record_opt_name()
 * 2.9.0
-   - Encode atom values for string types when not nil or null
+   - Encode atom values for string types when not `nil` or `null`
+* 2.9.1
+   - Add `true` and `false` to the atom exceptions when converting to strings
 

--- a/src/avro_primitive.erl
+++ b/src/avro_primitive.erl
@@ -121,10 +121,11 @@ cast(Type, Value) when ?IS_BYTES_TYPE(Type) andalso
 cast(Type, Value) when ?IS_STRING_TYPE(Type) andalso
                        (is_list(Value) orelse is_binary(Value)) ->
   {ok, ?AVRO_VALUE(Type, erlang:iolist_to_binary(Value))};
-% Encode atom values for string types when not null or nil
+% Encode atom values for string types when not null, nil, or booleans
 cast(Type, Value) when ?IS_STRING_TYPE(Type) andalso
                        (is_atom(Value) andalso
-                       (Value =/= null andalso Value =/= nil)) ->
+                       (Value =/= null andalso Value =/= nil andalso
+                        Value =/= true andalso Value =/= false)) ->
   {ok, ?AVRO_VALUE(Type, erlang:atom_to_binary(Value, utf8))};
 cast(Type, Value) -> {error, {type_mismatch, Type, Value}}.
 

--- a/src/erlavro.app.src
+++ b/src/erlavro.app.src
@@ -1,7 +1,7 @@
 {application, erlavro,
   [
     {description, "Apache Avro support for Erlang/Elixir"},
-    {vsn, "2.9.0"},
+    {vsn, "2.9.1"},
     {registered, []},
     {applications, [
       kernel,

--- a/test/avro_binary_encoder_tests.erl
+++ b/test/avro_binary_encoder_tests.erl
@@ -177,11 +177,17 @@ encode_map_error_test() ->
                encode(fun(_) -> error(unexpected) end, Type, Value)).
 
 encode_union_test() ->
-  Type = avro_union:type([null, string]),
+  Type = avro_union:type([null, string, boolean]),
   Value1 = avro_union:new(Type, null),
-  Value2 = avro_union:new(Type, "a"),
+  Value2 = avro_union:new(Type, nil),
+  Value3 = avro_union:new(Type, "a"),
+  Value4 = avro_union:new(Type, true),
+  Value5 = avro_union:new(Type, false),
   ?assertBinEq([0], encode_value(Value1)),
-  ?assertBinEq([long(1), long(1), 97], encode_value(Value2)).
+  ?assertBinEq([0], encode_value(Value2)),
+  ?assertBinEq([long(1), long(1), 97], encode_value(Value3)),
+  ?assertBinEq([long(2), <<1>>], encode_value(Value4)),
+  ?assertBinEq([long(2), <<0>>], encode_value(Value5)).
 
 encode_fixed_test() ->
   Type = avro_fixed:type("FooBar", 2),


### PR DESCRIPTION
The boolean atoms 'true' and 'false' should be skipped when converting
to a string. Otherwise, when handling a union type which specifies
strings before booleans, the values 'true' or 'false' will get turned to
a string, which corrupts data at serialization time.

Since the null and nil atoms are already skipped to avoid type
confusion, it seems reasonable to extend the exception to booleans. Most
encoding of strings should ideally be done using binaries in accordance
to the documentation, which specifies 'iolist()' as the type for strings
and atoms appear to be undocumented.

This current issue wasn't found through any regular test in this
repository, but was found in property-test in a private corporate
project. Without sharing similar schemas it is a bit complex to extend
the existing tests for an undocumented feature, so I skipped it for now.