### PR TITLE
Add macro to be able to extract records from elixir

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+* 2.9.4
+   - Dropped `?MODULE` from required error in erlavro.hrl to allow elixir to extract record details
 * 2.9.3
    - Add OCF decoder hook
    - Dialyzer fixes

--- a/include/erlavro.hrl
+++ b/include/erlavro.hrl
@@ -48,7 +48,7 @@
          N =:= ?AVRO_DOUBLE  orelse
          N =:= ?AVRO_BYTES)).
 
--define(AVRO_REQUIRED, erlang:error({required_field_missed, ?MODULE, ?LINE})).
+-define(AVRO_REQUIRED, erlang:error({required_field_missed, ?LINE})).
 
 -define(AVRO_NS_GLOBAL, <<"">>).
 -define(AVRO_NO_DOC, <<"">>).


### PR DESCRIPTION
Potential solution for #106. Elixirs record extraction API does include means to pass macro values.