### PR TITLE
Add map() to the avro:out() union type

### DIFF
--- a/src/avro.erl
+++ b/src/avro.erl
@@ -129,6 +129,7 @@
              | integer()
              | float()
              | binary()
+             | map()
              | [avro:out()]
              | [{name(), avro:out()}].
 


### PR DESCRIPTION
Given codec options `{map_type, map}` and/or `{record_type, map}` erlavro can actually decode to maps, so the `avro:out()` type should reflect it