### PR TITLE
Update :avro_util.is_valid_name_char/1 to allow hyphens

### DIFF
--- a/src/avro_util.erl
+++ b/src/avro_util.erl
@@ -560,7 +560,8 @@ is_valid_name_head(S) ->
 
 %% @private In addition to what applies to leading char, body char can be 0-9.
 is_valid_name_char(S) -> is_valid_name_head(S) orelse
-                         (S >= $0 andalso S =< $9).
+                         (S >= $0 andalso S =< $9) orelse
+                          S =:= $-.
 
 %% @private
 verify_type_name(Type) ->

--- a/test/avro_util_tests.erl
+++ b/test/avro_util_tests.erl
@@ -48,7 +48,7 @@ tokens_ex_test() ->
   ?assertEqual(["ab", "cd"], tokens_ex("ab.cd", $.)).
 
 is_valid_name_test() ->
-  ValidNames = ["_", "a", "Aa1", "a_A"],
+  ValidNames = ["_", "a", "Aa1", "a_A", "a-A"],
   InvalidNames = ["", "1", " a", "a ", " a ", ".", "a.b.c"],
   [?assert(is_valid_name(Name)) || Name <- ValidNames],
   [?assertNot(is_valid_name(Name)) || Name <- InvalidNames].


### PR DESCRIPTION
I have no idea what I'm doing, however...

I modified [this line](https://github.com/carsdotcom/cars_platform/blob/97127c9878796da5dafdb0236f32bd3717ecddae/apps/manifold/test/manifold/consumers/data_science/price_badge_consumer_test.exs#L16) in this branch: `marketplace/CARS-104/debug-ml-listing-consumer` by adding a hyphen to the namespace.  The tests failed with the `:invalid_name` error as seen in NP.
I then updated `cars_platform/apps/kafka_repo/mix.exs`'s erl_avro dep to point to my local repo
`{:erlavro, path: "/Users/leepage/repos/erlavro", override: true},`
and the test passed.  I dont know if this is what we need or if there will be any downstream effects.

Input appreciated.