### PR TITLE
feat: export ocf encode_header and make_block functions

### DIFF
--- a/src/avro_ocf.erl
+++ b/src/avro_ocf.erl
@@ -29,6 +29,8 @@
         , decode_binary/2
         , decode_file/1
         , decode_file/2
+        , encode_header/1
+        , make_block/2
         , make_header/1
         , make_header/2
         , make_ocf/2
@@ -169,8 +171,7 @@ make_ocf(Header, Objects) ->
   DataBytes = make_block(Header, Objects),
   [HeaderBytes, DataBytes].
 
-%%%_* Internal functions =======================================================
-
+%% @doc Encode the given ocf header.
 -spec encode_header(header()) -> iodata().
 encode_header(Header) ->
   HeaderFields =
@@ -181,6 +182,7 @@ encode_header(Header) ->
   HeaderRecord = avro_record:new(ocf_schema(), HeaderFields),
   avro_binary_encoder:encode_value(HeaderRecord).
 
+%% @doc Encode the given objects as one data block.
 -spec make_block(header(), [binary()]) -> iodata().
 make_block(Header, Objects) ->
   Count = length(Objects),
@@ -191,6 +193,8 @@ make_block(Header, Objects) ->
   , Data
   , Header#header.sync
   ].
+
+%%%_* Internal functions =======================================================
 
 %% Raise an exception if meta has a bad format.
 %% Otherwise return the formatted metadata entries


### PR DESCRIPTION
The purpose of this PR is to export the ocf `encode_header` and `make_block` functions. This can enable appending avro blocks to a remote file (e.g. via http requests).

It is the same approach as what is done in the `append_file` function. The user could send the encoded header calling an API and periodically send multiple blocks of avro messages to be appended to the file.