### PR TITLE
Update Rebar config script

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+* 2.9.8
+   - Removed support for Rebar 2
 * 2.9.7
    - Export OCF make_header and make_block functions
 * 2.9.6

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,4 +1,3 @@
-
 case os:getenv("TRAVIS") of
   "true" ->
     JobId   = os:getenv("TRAVIS_JOB_ID"),
@@ -9,4 +8,3 @@ case os:getenv("TRAVIS") of
   _ ->
     CONFIG
 end.
-

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,6 +1,5 @@
-IsRebar3 = erlang:function_exported(rebar3, main, 1),
 
-CONFIG0 = case os:getenv("TRAVIS") of
+case os:getenv("TRAVIS") of
   "true" ->
     JobId   = os:getenv("TRAVIS_JOB_ID"),
     [{coveralls_service_job_id, JobId},
@@ -9,21 +8,5 @@ CONFIG0 = case os:getenv("TRAVIS") of
      {coveralls_service_name , "travis-ci"} | CONFIG];
   _ ->
     CONFIG
-end.
-
-case IsRebar3 of
-    true ->
-        CONFIG0;
-    false ->
-        Rebar3Deps = proplists:get_value(deps, CONFIG),
-        Rebar2Deps = [
-            {jsone, ".*",
-                {git, "https://github.com/sile/jsone",
-                    {tag, proplists:get_value(jsone, Rebar3Deps)}}},
-            {snappyer, ".*",
-                {git, "https://github.com/zmstone/snappyer",
-                    {tag, proplists:get_value(snappyer, Rebar3Deps)}}}
-        ],
-        lists:keyreplace(deps, 1, CONFIG, {deps, Rebar2Deps})
 end.
 

--- a/src/erlavro.app.src
+++ b/src/erlavro.app.src
@@ -13,7 +13,7 @@
     {modules,[]},
     {licenses, ["Apache License 2.0"]},
     {links, [{"Github", "https://github.com/klarna/erlavro"}]},
-    {build_tools, ["make", "rebar", "rebar3"]},
+    {build_tools, ["make", "rebar3"]},
     {files, ["src", "include", "rebar.config", "rebar.config.script",
              "README.md", "LICENSE", "Makefile", "elvis.config"]}
   ]}.


### PR DESCRIPTION
Assume that Rebar3 is the one being used now given that Rebar2 is no longer supported.

This is a crude attempt to remove what is no longer needed.