### PR TITLE
Encode empty map as an empty JSON object

### DIFF
--- a/src/avro_json_encoder.erl
+++ b/src/avro_json_encoder.erl
@@ -347,7 +347,10 @@ do_encode_value(Array) when ?IS_ARRAY_VALUE(Array) ->
   lists:map(fun do_encode_value/1, ?AVRO_VALUE_DATA(Array));
 do_encode_value(Map) when ?IS_MAP_VALUE(Map) ->
   L = avro_map:to_list(Map),
-  lists:map(fun encode_field_with_value/1, L);
+  lists:foldl(fun (X, Acc) ->
+                  {Key, Value} = encode_field_with_value(X),
+                  maps:put(Key, Value, Acc)
+              end, #{}, L);
 do_encode_value(Fixed) when ?IS_FIXED_VALUE(Fixed) ->
   %% jsone treats binary as utf8 string
   ?INLINE(encode_binary(?AVRO_VALUE_DATA(Fixed)));

--- a/test/avro_json_encoder_tests.erl
+++ b/test/avro_json_encoder_tests.erl
@@ -249,6 +249,16 @@ encode_map_test() ->
   ?assertEqual(<<"{\"v1\":{\"int\":1},\"v2\":null,\"v3\":{\"int\":2}}">>,
                Json1).
 
+encode_empty_map_test() ->
+  MapType = avro_map:type(avro_union:type([int, null])),
+  MapValue0 = avro_map:new(MapType, []),
+  Json0 = encode_value(MapValue0),
+  ?assertEqual(<<"{}">>, Json0),
+
+  MapValue1 = avro_map:new(MapType, #{}),
+  Json1 = encode_value(MapValue1),
+  ?assertEqual(<<"{}">>, Json1).
+
 encode_fixed_type_test() ->
   Type = avro_fixed:type("FooBar", 2,
                          [ {namespace, "name.space"}


### PR DESCRIPTION
Don't encode the empty map as an JSON array. The current behavior encodes
map values as JSON objects *or* a JSON array depending on the map being empty or not. 