### PR TITLE
Improve `@aliases` support

### DIFF
--- a/src/avro_json_decoder.erl
+++ b/src/avro_json_decoder.erl
@@ -212,7 +212,7 @@ parse_record_field(Attrs) ->
   Aliases   = avro_util:get_opt(<<"aliases">>, Attrs, []),
   FieldType = parse_schema(Type),
   #avro_record_field
-  { name    = Name
+  { name    = ?NAME(Name)
   , doc     = Doc
   , type    = FieldType
   , default = Default

--- a/src/avro_record.erl
+++ b/src/avro_record.erl
@@ -162,16 +162,18 @@ get_all_field_types(Type) when ?IS_RECORD_TYPE(Type) ->
 %% in a triple list.
 %% @end
 -spec get_all_field_data(avro_type()) -> [ {field_name()
+                                         , [field_name()]
                                          , type_or_name()
                                          , ?NO_VALUE | avro:in() | avro_value()
                                          }].
 get_all_field_data(#avro_record_type{fields = Fields}) ->
   lists:map(
     fun(#avro_record_field{ name = FieldName
+                          , aliases = Aliases
                           , type = FieldTypeOrName
                           , default = Default
                           }) ->
-        {FieldName, FieldTypeOrName, Default}
+        {FieldName, Aliases, FieldTypeOrName, Default}
     end, Fields).
 
 %% @doc Parse fields' default values.

--- a/test/avro_tests.erl
+++ b/test/avro_tests.erl
@@ -54,7 +54,16 @@ get_aliases_test() ->
   ?assertEqual([], avro:get_aliases(avro_primitive:null_type())),
   ?assertEqual([], avro:get_aliases(avro_union:type([int]))),
   ?assertEqual([], avro:get_aliases(avro_array:type(string))),
-  ?assertEqual([], avro:get_aliases(avro_map:type(long))).
+  ?assertEqual([], avro:get_aliases(avro_map:type(long))),
+  Record = avro_record:type(<<"MyRecord">>, [], [{aliases, [<<"MyAlias">>]}]),
+  ?assertEqual([<<"MyAlias">>], avro:get_aliases(Record)),
+  RecordField = avro_record:define_field(
+                  new_name, <<"string">>, [{aliases, [<<"old_name">>]}]),
+  ?assertEqual([<<"old_name">>], avro:get_aliases(RecordField)),
+  Enum = avro_enum:type("MyEnum", ["a", "b"], [{aliases, [<<"MyAlias">>]}]),
+  ?assertEqual([<<"MyAlias">>], avro:get_aliases(Enum)),
+  Fixed = avro_fixed:type("MyFixed", 2, [{aliases, [<<"MyAlias">>]}]),
+  ?assertEqual([<<"MyAlias">>], avro:get_aliases(Fixed)).
 
 get_type_namespace_test() ->
   ?assertEqual(?NS_GLOBAL, avro:get_type_namespace(avro_primitive:null_type())),


### PR DESCRIPTION
* Make sure `avro:is_same_type` takes them into account
* Make sure `avro:is_compatible` takes them into account

With this change the `is_compatible/2` will be able to say that the schema

```json
{
    "type": "record",
    "name": "EventMeta",
    "fields": [
        {"name": "to_stay", "type": "string"},
        {"name": "new_name", "type": "string", "aliases": ["to_rename"]}
    ]
}
```

is backwards compatible with

```json
{
    "type": "record",
    "name": "EventMeta",
    "fields": [
        {"name": "to_stay", "type": "string"},
        {"name": "to_rename", "type": "string"}
    ]
}
```