### PR TITLE
bump snappyer to 1.2.9

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
 {edoc_opts,           [{preprocess, true}]}.
 {deps,
  [ {jsone, "1.4.6"},
-   {snappyer, "1.2.8"}
+   {snappyer, "1.2.9"}
  ]}.
 
 {cover_opts, [verbose]}.


### PR DESCRIPTION
needed for building with gcc-13