### PR TITLE
Add map type schema store

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -1,0 +1,24 @@
+name: Erlang CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: erlang:26
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run tests
+      run: make eunit && make cover

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+* 2.10.0
+   - Add map as avro store, and use it as default.
+   - Changed to store type aliases as type's full name index, so the type store map (or dict) is less bloated.
 * 2.9.10
    - Optimize avro:is_same_type/2
    - Upgrade jsone to 1.8.1

--- a/src/avro_json_encoder.erl
+++ b/src/avro_json_encoder.erl
@@ -347,7 +347,10 @@ do_encode_value(Array) when ?IS_ARRAY_VALUE(Array) ->
   lists:map(fun do_encode_value/1, ?AVRO_VALUE_DATA(Array));
 do_encode_value(Map) when ?IS_MAP_VALUE(Map) ->
   L = avro_map:to_list(Map),
-  lists:map(fun encode_field_with_value/1, L);
+  lists:foldl(fun (X, Acc) ->
+                  {Key, Value} = encode_field_with_value(X),
+                  maps:put(Key, Value, Acc)
+              end, #{}, L);
 do_encode_value(Fixed) when ?IS_FIXED_VALUE(Fixed) ->
   %% jsone treats binary as utf8 string
   ?INLINE(encode_binary(?AVRO_VALUE_DATA(Fixed)));

--- a/src/avro_util.erl
+++ b/src/avro_util.erl
@@ -83,10 +83,10 @@ ensure_lkup_fun(Sc) ->
     false -> make_lkup_fun(?ASSIGNED_NAME, Sc)
   end.
 
-%% @doc Make a schema store (dict based) and wrap it in a lookup fun.
+%% @doc Make a schema store (map based) and wrap it in a lookup fun.
 -spec make_lkup_fun(name_raw(), avro_type()) -> lkup().
 make_lkup_fun(AssignedName, Type) ->
-  Store0 = avro_schema_store:new([dict]),
+  Store0 = avro_schema_store:new([map]),
   Store = avro_schema_store:add_type(AssignedName, Type, Store0),
   avro_schema_store:to_lookup_fun(Store).
 

--- a/test/avro_json_encoder_tests.erl
+++ b/test/avro_json_encoder_tests.erl
@@ -249,6 +249,16 @@ encode_map_test() ->
   ?assertEqual(<<"{\"v1\":{\"int\":1},\"v2\":null,\"v3\":{\"int\":2}}">>,
                Json1).
 
+encode_empty_map_test() ->
+  MapType = avro_map:type(avro_union:type([int, null])),
+  MapValue0 = avro_map:new(MapType, []),
+  Json0 = encode_value(MapValue0),
+  ?assertEqual(<<"{}">>, Json0),
+
+  MapValue1 = avro_map:new(MapType, #{}),
+  Json1 = encode_value(MapValue1),
+  ?assertEqual(<<"{}">>, Json1).
+
 encode_fixed_type_test() ->
   Type = avro_fixed:type("FooBar", 2,
                          [ {namespace, "name.space"}

--- a/test/avro_schema_store_tests.erl
+++ b/test/avro_schema_store_tests.erl
@@ -35,11 +35,13 @@ get_all_types_test() ->
       ok = avro_schema_store:close(Store)
     end,
   ok = TestFun(avro_schema_store:new([{name, ?MODULE}])),
-  ok = TestFun(avro_schema_store:new([dict])).
+  ok = TestFun(avro_schema_store:new([dict])),
+  ok = TestFun(avro_schema_store:new([map])).
 
 is_store_test() ->
   ?assertNot(avro_schema_store:is_store(<<"json">>)),
   ?assert(avro_schema_store:is_store(avro_schema_store:new([dict]))),
+  ?assert(avro_schema_store:is_store(avro_schema_store:new([map]))),
   ?assert(avro_schema_store:is_store(avro_schema_store:new([]))).
 
 ensure_store_test() ->
@@ -52,7 +54,8 @@ ensure_store_test() ->
   ?assertEqual(1, avro_schema_store:ensure_store(1)),
   ?assertEqual(atom, avro_schema_store:ensure_store(atom)),
   ?assertEqual({dict, dict:new()},
-               avro_schema_store:ensure_store({dict, dict:new()})).
+               avro_schema_store:ensure_store({dict, dict:new()})),
+  ?assertEqual(#{}, avro_schema_store:ensure_store(#{})).
 
 flatten_type_test() ->
   Type = avro_array:type(test_record()),
@@ -81,7 +84,8 @@ add_type_test() ->
         ok = avro_schema_store:close(Store1)
     end,
   ok = TestFun(avro_schema_store:new()),
-  ok = TestFun(avro_schema_store:new([dict])).
+  ok = TestFun(avro_schema_store:new([dict])),
+  ok = TestFun(avro_schema_store:new([map])).
 
 lookup(Name, Store) ->
   avro_schema_store:lookup_type(Name, Store).

--- a/test/avro_tests.erl
+++ b/test/avro_tests.erl
@@ -337,7 +337,7 @@ wrapped_union_cast_test() ->
   Rec1 = avro_record:type("rec1", [avro_record:define_field("f1", int)]),
   Rec2 = avro_record:type("rec2", [avro_record:define_field("f1", int)]),
   Union = avro_union:type(["rec1", "rec2"]),
-  Store0 = avro_schema_store:new([dict]),
+  Store0 = avro_schema_store:new([map]),
   Store1 = avro_schema_store:add_type(Rec1, Store0),
   Store = avro_schema_store:add_type(Rec2, Store1),
   Lkup = avro_util:ensure_lkup_fun(Store),


### PR DESCRIPTION
This HEAD is tagged as `2.10.0` in [emqx fork](https://github.com/emqx/erlavro)

- Pulled in #116
- Added GitHub actions for ci.
- Add map as avro store, and use it as default.
- Changed to store type aliases as type's full name index, so the type store map (or dict) is less bloated.