### PR TITLE
fix dialyzer error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+* 2.10.1
+   - Fix dialyzer error.
 * 2.10.0
    - Add map as avro store, and use it as default.
    - Changed to store type aliases as type's full name index, so the type store map (or dict) is less bloated.

--- a/src/avro_schema_store.erl
+++ b/src/avro_schema_store.erl
@@ -262,7 +262,7 @@ add_aliases([Alias | More], FullName, Store) ->
   add_aliases(More, FullName, NewStore).
 
 %% @private
--spec add_type_by_name([fullname()], avro_type(), store()) ->
+-spec add_type_by_name(fullname(), avro_type(), store()) ->
         store() | no_return().
 add_type_by_name(Name, Type, Store) ->
   case get_type_from_store(Name, Store) of


### PR DESCRIPTION
The previous PR changed `add_type_by_name/3` from taking a list of Names to taking a single Name, but didn't adjust the `-spec` to match, which caused a dialyzer error.