### PR TITLE
feat: optionally materialize missing fields with defaults on decode

### DIFF
--- a/src/avro_decoder_hooks.erl
+++ b/src/avro_decoder_hooks.erl
@@ -62,7 +62,8 @@
 
 -module(avro_decoder_hooks).
 
--export([ tag_unions/0
+-export([ materialize_defaults/1
+        , tag_unions/0
         , pretty_print_hist/0
         , print_debug_trace/2
         ]).
@@ -75,6 +76,16 @@
 
 -type count() :: non_neg_integer().
 -type trace_hist_entry() :: {push, _, _} | {pop, _} | pop.
+
+%% @doc Materialize omitted record field defaults while decoding Avro JSON.
+%% Binary decoding is passed through unchanged.
+%% @end
+-spec materialize_defaults(avro:schema_all()) -> avro:decoder_hook_fun().
+materialize_defaults(Schema) ->
+  Lkup = avro_util:ensure_lkup_fun(Schema),
+  fun(Type, SubName, Data, DecodeFun) ->
+      materialize_defaults(Type, SubName, Data, DecodeFun, Lkup)
+  end.
 
 %% @doc By default, decoders do not tag union values.
 %% This hook function is to tag union values with union type names
@@ -131,6 +142,45 @@ pretty_print_hist() ->
   end.
 
 %%%_* Internal functions =======================================================
+
+-spec materialize_defaults(avro:avro_type(), avro:name() | integer() | none,
+                           term(), function(), avro:lkup_fun()) -> term().
+materialize_defaults(#avro_record_type{} = Type, none, Attrs,
+                     DecodeFun, Lkup) when is_list(Attrs) ->
+  DecodeFun(add_missing_defaults(Type, Attrs, Lkup));
+materialize_defaults(_Type, _SubName, Data, DecodeFun, _Lkup) ->
+  DecodeFun(Data).
+
+-spec add_missing_defaults(avro:record_type(),
+                           [{avro:name(), term()}], avro:lkup_fun()) ->
+        [{avro:name(), term()}].
+add_missing_defaults(Type, Attrs, Lkup) ->
+  Defaults = lists:filtermap(
+               fun(FieldData) ->
+                   missing_default(FieldData, Attrs, Lkup)
+               end,
+               avro_record:get_all_field_data(Type)),
+  Attrs ++ Defaults.
+
+-spec missing_default({avro:name(), [avro:name()], avro:type_or_name(), term()},
+                      [{avro:name(), term()}], avro:lkup_fun()) ->
+        false | {true, {avro:name(), jsone:json_value()}}.
+missing_default({FieldName, Aliases, FieldType, Default}, Attrs, Lkup) ->
+  Names = [FieldName | Aliases],
+  IsPresent = lists:any(
+                fun(Name) -> lists:keymember(Name, 1, Attrs) end,
+                Names),
+  case {IsPresent, Default} of
+    {false, undefined} -> false;
+    {false, _} -> {true, {FieldName, default_json(FieldType, Default, Lkup)}};
+    {true, _} -> false
+  end.
+
+-spec default_json(avro:type_or_name(), term(), avro:lkup_fun()) ->
+        jsone:json_value().
+default_json(Type, Default, Lkup) ->
+  Encoded = iolist_to_binary(avro_json_encoder:encode(Lkup, Type, Default)),
+  jsone:decode(Encoded, [{object_format, tuple}]).
 
 %% @private
 tag_unions(#avro_union_type{} = T, SubInfo, DecodeIn, DecodeFun) ->

--- a/src/avro_decoder_hooks.erl
+++ b/src/avro_decoder_hooks.erl
@@ -164,7 +164,7 @@ add_missing_defaults(Type, Attrs, Lkup) ->
 
 -spec missing_default({avro:name(), [avro:name()], avro:type_or_name(), term()},
                       [{avro:name(), term()}], avro:lkup_fun()) ->
-        false | {true, {avro:name(), jsone:json_value()}}.
+        false | {true, {avro:name(), avro_json_compat:json_value()}}.
 missing_default({FieldName, Aliases, FieldType, Default}, Attrs, Lkup) ->
   Names = [FieldName | Aliases],
   IsPresent = lists:any(
@@ -177,10 +177,10 @@ missing_default({FieldName, Aliases, FieldType, Default}, Attrs, Lkup) ->
   end.
 
 -spec default_json(avro:type_or_name(), term(), avro:lkup_fun()) ->
-        jsone:json_value().
+        avro_json_compat:json_value().
 default_json(Type, Default, Lkup) ->
   Encoded = iolist_to_binary(avro_json_encoder:encode(Lkup, Type, Default)),
-  jsone:decode(Encoded, [{object_format, tuple}]).
+  avro_json_compat:decode(Encoded, [{object_format, tuple}]).
 
 %% @private
 tag_unions(#avro_union_type{} = T, SubInfo, DecodeIn, DecodeFun) ->

--- a/test/avro_decoder_hooks_tests.erl
+++ b/test/avro_decoder_hooks_tests.erl
@@ -110,7 +110,24 @@ materialize_defaults_wrapped_test() ->
       <<"mode">> => #{<<"string">> => <<"fallback">>},
       <<"metadata">> => #{<<"source">> => <<"local">>}
     },
-    jsone:decode(
+    avro_json_compat:decode(
+      iolist_to_binary(avro_json_encoder:encode_value(Decoded)),
+      [{object_format, map}])).
+
+materialize_recursive_defaults_test() ->
+  Store = recursive_defaults_store(),
+  Hook = avro_decoder_hooks:materialize_defaults(Store),
+  Options = avro:make_decoder_options([{hook, Hook}]),
+  Decoded = avro_json_decoder:decode_value(
+              <<"{}">>, <<"Config">>, Store, Options),
+  ?assertEqual(
+    #{
+      <<"settings">> => #{
+        <<"subsettings0">> => #{<<"x">> => 1},
+        <<"subsettings1">> => #{<<"y">> => 2}
+      }
+    },
+    avro_json_compat:decode(
       iolist_to_binary(avro_json_encoder:encode_value(Decoded)),
       [{object_format, map}])).
 
@@ -165,7 +182,7 @@ decode_defaults(DecoderOptions) ->
       <<"mode">> => #{<<"string">> => <<"fallback">>},
       <<"metadata">> => #{<<"source">> => <<"local">>}
     },
-    jsone:decode(
+    avro_json_compat:decode(
       iolist_to_binary(Encoded), [{object_format, map}])),
   Decoded.
 
@@ -206,7 +223,58 @@ defaults_store() ->
       }
     ]
   },
-  Json = iolist_to_binary(jsone:encode(Schema, [native_utf8])),
+  Json = iolist_to_binary(avro_json_compat:encode(Schema, [native_utf8])),
+  avro_schema_store:import_schema_json(
+    Json, avro_schema_store:new([map])).
+
+recursive_defaults_store() ->
+  Schema = #{
+    <<"type">> => <<"record">>,
+    <<"name">> => <<"Config">>,
+    <<"fields">> => [
+      #{
+        <<"name">> => <<"settings">>,
+        <<"type">> => #{
+          <<"type">> => <<"record">>,
+          <<"name">> => <<"Settings">>,
+          <<"fields">> => [
+            #{
+              <<"name">> => <<"subsettings0">>,
+              <<"type">> => #{
+                <<"type">> => <<"record">>,
+                <<"name">> => <<"Subsettings0">>,
+                <<"fields">> => [
+                  #{
+                    <<"name">> => <<"x">>,
+                    <<"type">> => <<"int">>,
+                    <<"default">> => 1
+                  }
+                ]
+              },
+              <<"default">> => #{}
+            },
+            #{
+              <<"name">> => <<"subsettings1">>,
+              <<"type">> => #{
+                <<"type">> => <<"record">>,
+                <<"name">> => <<"Subsettings1">>,
+                <<"fields">> => [
+                  #{
+                    <<"name">> => <<"y">>,
+                    <<"type">> => <<"int">>,
+                    <<"default">> => 2
+                  }
+                ]
+              },
+              <<"default">> => #{}
+            }
+          ]
+        },
+        <<"default">> => #{<<"subsettings0">> => #{}}
+      }
+    ]
+  },
+  Json = iolist_to_binary(avro_json_compat:encode(Schema, [native_utf8])),
   avro_schema_store:import_schema_json(
     Json, avro_schema_store:new([map])).
 

--- a/test/avro_decoder_hooks_tests.erl
+++ b/test/avro_decoder_hooks_tests.erl
@@ -95,6 +95,49 @@ tag_unions_test() ->
                   ]}
      ], Decoder("com.example.MyRecord", Bin)).
 
+materialize_defaults_wrapped_test() ->
+  Store = defaults_store(),
+  Hook = avro_decoder_hooks:materialize_defaults(Store),
+  Options = avro:make_decoder_options([{hook, Hook}]),
+  Decoded = avro_json_decoder:decode_value(
+              <<"{}">>, <<"Config">>, Store, Options),
+  Enum = avro_record:get_value(<<"format">>, Decoded),
+  ?assertEqual(<<"json">>, avro_enum:get_value(Enum)),
+  ?assertEqual(
+    #{
+      <<"format">> => <<"json">>,
+      <<"retries">> => 3,
+      <<"mode">> => #{<<"string">> => <<"fallback">>},
+      <<"metadata">> => #{<<"source">> => <<"local">>}
+    },
+    jsone:decode(
+      iolist_to_binary(avro_json_encoder:encode_value(Decoded)),
+      [{object_format, map}])).
+
+materialize_defaults_unwrapped_test_() ->
+  [
+    {"proplist", fun() ->
+         ?assertEqual(
+           [
+             {<<"format">>, <<"json">>},
+             {<<"retries">>, 3},
+             {<<"mode">>, <<"fallback">>},
+             {<<"metadata">>, [{<<"source">>, <<"local">>}]}
+           ],
+           decode_defaults([]))
+     end},
+    {"map", fun() ->
+         ?assertEqual(
+           #{
+             <<"format">> => <<"json">>,
+             <<"retries">> => 3,
+             <<"mode">> => <<"fallback">>,
+             <<"metadata">> => #{<<"source">> => <<"local">>}
+           },
+           decode_defaults([{record_type, map}, {map_type, map}]))
+     end}
+  ].
+
 %% @private
 corrupt_encoded(avro_binary, Bin) ->
   %% for binary format, chopping off the last byte should corrupt the data
@@ -106,6 +149,66 @@ corrupt_encoded(avro_json, Bin) ->
   %% for json, replace the last string with an integer
   %% to violate the type check
   binary:replace(Bin, <<"\"my-string\"">>, <<"42">>).
+
+decode_defaults(DecoderOptions) ->
+  Store = defaults_store(),
+  Hook = avro_decoder_hooks:materialize_defaults(Store),
+  Decoder = avro:make_decoder(
+              Store,
+              [{encoding, avro_json}, {hook, Hook} | DecoderOptions]),
+  Decoded = Decoder(<<"Config">>, <<"{}">>),
+  Encoded = avro_json_encoder:encode(Store, <<"Config">>, Decoded),
+  ?assertEqual(
+    #{
+      <<"format">> => <<"json">>,
+      <<"retries">> => 3,
+      <<"mode">> => #{<<"string">> => <<"fallback">>},
+      <<"metadata">> => #{<<"source">> => <<"local">>}
+    },
+    jsone:decode(
+      iolist_to_binary(Encoded), [{object_format, map}])),
+  Decoded.
+
+defaults_store() ->
+  Schema = #{
+    <<"type">> => <<"record">>,
+    <<"name">> => <<"Config">>,
+    <<"fields">> => [
+      #{
+        <<"name">> => <<"format">>,
+        <<"type">> => #{
+          <<"type">> => <<"enum">>,
+          <<"name">> => <<"ToolFormat">>,
+          <<"symbols">> => [<<"json">>, <<"binary">>]
+        },
+        <<"default">> => <<"json">>
+      },
+      #{
+        <<"name">> => <<"retries">>,
+        <<"type">> => <<"int">>,
+        <<"default">> => 3
+      },
+      #{
+        <<"name">> => <<"mode">>,
+        <<"type">> => [<<"null">>, <<"string">>],
+        <<"default">> => <<"fallback">>
+      },
+      #{
+        <<"name">> => <<"metadata">>,
+        <<"type">> => #{
+          <<"type">> => <<"record">>,
+          <<"name">> => <<"Metadata">>,
+          <<"fields">> => [
+            #{<<"name">> => <<"source">>, <<"type">> => <<"string">>}
+          ]
+        },
+        <<"default">> => #{<<"source">> => <<"local">>}
+      }
+    ]
+  },
+  Json = iolist_to_binary(jsone:encode(Schema, [native_utf8])),
+  avro_schema_store:import_schema_json(
+    Json, avro_schema_store:new([map])).
 
 %% @private
 define_field(Name, Type) -> avro_record:define_field(Name, Type).

--- a/test/avro_decoder_hooks_tests.erl
+++ b/test/avro_decoder_hooks_tests.erl
@@ -107,7 +107,6 @@ materialize_defaults_wrapped_test() ->
     #{
       <<"format">> => <<"json">>,
       <<"retries">> => 3,
-      <<"mode">> => #{<<"string">> => <<"fallback">>},
       <<"metadata">> => #{<<"source">> => <<"local">>}
     },
     avro_json_compat:decode(
@@ -138,7 +137,6 @@ materialize_defaults_unwrapped_test_() ->
            [
              {<<"format">>, <<"json">>},
              {<<"retries">>, 3},
-             {<<"mode">>, <<"fallback">>},
              {<<"metadata">>, [{<<"source">>, <<"local">>}]}
            ],
            decode_defaults([]))
@@ -148,7 +146,6 @@ materialize_defaults_unwrapped_test_() ->
            #{
              <<"format">> => <<"json">>,
              <<"retries">> => 3,
-             <<"mode">> => <<"fallback">>,
              <<"metadata">> => #{<<"source">> => <<"local">>}
            },
            decode_defaults([{record_type, map}, {map_type, map}]))
@@ -179,7 +176,6 @@ decode_defaults(DecoderOptions) ->
     #{
       <<"format">> => <<"json">>,
       <<"retries">> => 3,
-      <<"mode">> => #{<<"string">> => <<"fallback">>},
       <<"metadata">> => #{<<"source">> => <<"local">>}
     },
     avro_json_compat:decode(
@@ -204,11 +200,6 @@ defaults_store() ->
         <<"name">> => <<"retries">>,
         <<"type">> => <<"int">>,
         <<"default">> => 3
-      },
-      #{
-        <<"name">> => <<"mode">>,
-        <<"type">> => [<<"null">>, <<"string">>],
-        <<"default">> => <<"fallback">>
       },
       #{
         <<"name">> => <<"metadata">>,


### PR DESCRIPTION
Add an optional hook which materializes defaults for structs/enums. 

Sample:
```erlang
SchemaJson = jsone:encode(#{
    <<"type">> => <<"record">>,
    <<"name">> => <<"Config">>,
    <<"fields">> => [
        #{
            <<"name">> => <<"format">>,
            <<"type">> => #{
                <<"type">> => <<"enum">>,
                <<"name">> => <<"ToolFormat">>,
                <<"symbols">> => [<<"json">>, <<"binary">>]
            },
            <<"default">> => <<"json">>
        }
    ]
}),

Store0 = avro_schema_store:new([map]),
Store = avro_schema_store:import_schema_json(SchemaJson, Store0),

%% Here, create the hook
Hook = avro_decoder_hooks:materialize_defaults(Store),
Options = avro:make_decoder_options([{hook, Hook}]),

Decoded = avro_json_decoder:decode_value(
    %% No format field 
    <<"{}">>,
    <<"Config">>,
    Store,
    Options
),

Encoded = iolist_to_binary(
    avro_json_encoder:encode_value(Decoded)
).
```

Result:

```erlang
%% format is materialized
Encoded = <<"{\"format\":\"json\"}">>.
```